### PR TITLE
Add stub CLI commands to replace mario app

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,9 @@ ignore = C0114,C0116,D100,D103,W0012
 linters = eradicate,isort,mccabe,pycodestyle,pydocstyle,pyflakes,pylint
 max_line_length = 90
 
+[pylama:pydocstyle]
+convention = pep257
+
 [tool:pytest]
 log_level = DEBUG
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,17 +1,84 @@
 from tim.cli import main
 
 
-def test_cli_no_options(caplog, runner):
-    result = runner.invoke(main)
+def test_main_group_no_options_configures_correctly_and_invokes_result_callback(
+    caplog, runner
+):
+    result = runner.invoke(main, ["ping"])
     assert result.exit_code == 0
     assert "Logger 'root' configured with level=INFO" in caplog.text
-    assert "Running process" in caplog.text
     assert "Total time to complete process" in caplog.text
 
 
-def test_cli_all_options(caplog, runner):
-    result = runner.invoke(main, ["--verbose"])
+def test_main_group_all_options_configures_correctly_and_invokes_result_callback(
+    caplog, runner
+):
+    result = runner.invoke(main, ["--verbose", "ping"])
     assert result.exit_code == 0
     assert "Logger 'root' configured with level=DEBUG" in caplog.text
-    assert "Running process" in caplog.text
     assert "Total time to complete process" in caplog.text
+
+
+def test_aliases(caplog, runner):
+    result = runner.invoke(main, ["aliases"])
+    assert result.exit_code == 0
+    assert "'aliases' command not yet implemented" in caplog.text
+
+
+def test_indexes(caplog, runner):
+    result = runner.invoke(main, ["indexes"])
+    assert result.exit_code == 0
+    assert "'indexes' command not yet implemented" in caplog.text
+
+
+def test_ping(caplog, runner):
+    result = runner.invoke(main, ["ping"])
+    assert result.exit_code == 0
+    assert "'ping' command not yet implemented" in caplog.text
+
+
+def test_ingest_no_options(caplog, runner):
+    result = runner.invoke(
+        main,
+        ["ingest", "-s", "aspace", "tests/fixtures/sample-records.json"],
+    )
+    assert result.exit_code == 0
+    assert "'ingest' command not yet implemented" in caplog.text
+
+
+def test_ingest_all_options(caplog, runner):
+    result = runner.invoke(
+        main,
+        [
+            "ingest",
+            "-s",
+            "dspace",
+            "-c",
+            "title",
+            "--new",
+            "--auto",
+            "tests/fixtures/sample-records.json",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "'ingest' command not yet implemented" in caplog.text
+
+
+def test_promote(caplog, runner):
+    result = runner.invoke(main, ["promote", "-i", "test-index"])
+    assert result.exit_code == 0
+    assert "'promote' command not yet implemented" in caplog.text
+
+
+def test_reindex(caplog, runner):
+    result = runner.invoke(
+        main, ["reindex", "-i", "test-index", "-d", "destination-index"]
+    )
+    assert result.exit_code == 0
+    assert "'reindex' command not yet implemented" in caplog.text
+
+
+def test_delete(caplog, runner):
+    result = runner.invoke(main, ["delete", "-i", "test-index"])
+    assert result.exit_code == 0
+    assert "'delete' command not yet implemented" in caplog.text

--- a/tim/cli.py
+++ b/tim/cli.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import timedelta
 from time import perf_counter
+from typing import Optional
 
 import click
 
@@ -9,20 +10,153 @@ from tim.config import configure_logger, configure_sentry
 logger = logging.getLogger(__name__)
 
 
-@click.command()
+@click.group()
 @click.option(
     "-v", "--verbose", is_flag=True, help="Pass to log at debug level instead of info"
 )
-def main(verbose: bool) -> None:
-    start_time = perf_counter()
+@click.pass_context
+def main(ctx: click.Context, verbose: bool) -> None:
+    ctx.ensure_object(dict)
+    ctx.obj["START_TIME"] = perf_counter()
     root_logger = logging.getLogger()
     logger.info(configure_logger(root_logger, verbose))
     logger.info(configure_sentry())
-    logger.info("Running process")
 
-    # Do things here!
 
-    elapsed_time = perf_counter() - start_time
+@main.result_callback()
+@click.pass_context
+def log_process_time(
+    ctx: click.Context, result: Optional[object], **kwargs: dict  # noqa
+) -> None:
+    elapsed_time = perf_counter() - ctx.obj["START_TIME"]
     logger.info(
         "Total time to complete process: %s", str(timedelta(seconds=elapsed_time))
     )
+
+
+# OpenSearch instance commands
+
+
+@main.command()
+def aliases() -> None:
+    """List OpenSearch aliases and their associated indexes.
+
+    Find all aliases in the OpenSearch instance. For each alias, list the names of all
+    indexes associated with that alias in alphabetical order.
+    """
+    logger.info("'aliases' command not yet implemented")
+
+
+@main.command()
+def indexes() -> None:
+    """
+    List all OpenSearch indexes.
+
+    Find all indexes in the OpenSearch cluster. List the indexes in alphabetical order
+    by name. For each index, display: index name, number of documents, health, status,
+    UUID, size.
+    """
+    logger.info("'indexes' command not yet implemented")
+
+
+@main.command()
+def ping() -> None:
+    """
+    Ping OpenSearch.
+
+    Display the following: name, cluster, version, Lucene version.
+    """
+    logger.info("'ping' command not yet implemented")
+
+
+# Index commands
+
+
+@main.command()
+@click.option(
+    "-s",
+    "--source",
+    required=True,
+    help="Short name for source of records, e.g. 'dspace'. Will be used to identify or "
+    "create index according to the naming convention 'source-timestamp",
+)
+@click.option(
+    "-c",
+    "--consumer",
+    type=click.Choice(["os", "json", "title", "silent"]),
+    default="os",
+    show_default=True,
+    help="Consumer to use. Non-default optioins can be useful for development and "
+    "troubleshooting.",
+)
+@click.option(
+    "--new",
+    is_flag=True,
+    help="Create a new index instead of ingesting into the current production index "
+    "for the source",
+)
+@click.option(
+    "--auto",
+    is_flag=True,
+    help="Automatically promote index to the production alias on ingest copmletion. "
+    "Will demote the existing production index for the source if there is one.",
+)
+@click.argument("filepath", type=click.Path())
+def ingest(
+    source: str, consumer: str, new: bool, auto: bool, filepath: str  # noqa
+) -> None:
+    """
+    Bulk ingest records into an index.
+
+    By default, ingests into the current production index for the provided source."
+
+    FILEPATH: path to ingest file, use format "s3://bucketname/objectname" for s3.
+    """
+    logger.info("'ingest' command not yet implemented")
+
+
+@main.command()
+@click.option(
+    "-i", "--index", required=True, help="Name of the OpenSearch index to promote."
+)
+def promote(index: str) -> None:  # noqa
+    """
+    Promote an index to the production alias.
+
+    Demotes the existing production index for the provided source if there is one.
+    """
+    logger.info("'promote' command not yet implemented")
+
+
+@main.command()
+@click.option(
+    "-i",
+    "--index",
+    required=True,
+    help="Name of the OpenSearch index to copy.",
+)
+@click.option(
+    "-d",
+    "--destination",
+    required=True,
+    help="Name of the destination index.",
+)
+def reindex(index: str, destination: str) -> None:  # noqa
+    """
+    Reindex one index to another index.
+
+    Copy one index to another. The doc source must be present in the original index.
+    """
+    logger.info("'reindex' command not yet implemented")
+
+
+@main.command()
+@click.option(
+    "-i",
+    "--index",
+    required=True,
+    help="Name of the OpenSearch index to delete.",
+)
+def delete(index: str) -> None:  # noqa
+    """Delete an index."""
+    logger.info("'delete' command not yet implemented")


### PR DESCRIPTION
### What does this PR do?

Adds stub CLI commands representing all CLI functionality from the mario app.

### How can a reviewer manually see the effects of these changes?

Run any of the new commands to see initial stub log output, or run `pipenv run tim --help` to see help information on all the commands.

### Includes new or updated dependencies?

NO

### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/RDI-124

### Developer

- [x] All new ENV is documented in README (or there is none)
- [x] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer

- [ ] The commit message is clear and follows our guidelines (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes