### PR TITLE
Update OpenSearch endpoint ENV variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ TIMDEX! Index Manager (TIM) is a Python cli application for managing TIMDEX inde
 ## Optional ENV
 
 - `AWS_REGION` = Only needed if AWS region changes from the default of us-east-1.
-- `OPENSEARCH_ENDPOINT` = If using a local Docker OpenSearch instance, this isn't needed. Otherwise set to OpenSearch instance endpoint _without_ the http scheme, e.g. `search-timdex-env-1234567890.us-east-1.es.amazonaws.com`. Can also be passed directly to the CLI via the `--url` option.
 - `OPENSEARCH_REQUEST_TIMEOUT` = Only used for OpenSearch requests that tend to take longer than the default timeout of 10 seconds, such as bulk or index refresh requests. Defaults to 30 seconds if not set.
 - `SENTRY_DSN` = If set to a valid Sentry DSN, enables Sentry exception monitoring. This is not needed for local development.
 - `STATUS_UPDATE_INTERVAL` = The ingest process logs the # of records indexed every nth record (1000 by default). Set this env variable to any integer to change the frequency of logging status updates. Can be useful for development/debugging.
+- `TIMDEX_OPENSEARCH_ENDPOINT` = If using a local Docker OpenSearch instance, this isn't needed. Otherwise set to OpenSearch instance endpoint _without_ the http scheme, e.g. `search-timdex-env-1234567890.us-east-1.es.amazonaws.com`. Can also be passed directly to the CLI via the `--url` option.
 
 ## Development
 
@@ -37,5 +37,5 @@ To confirm the instance is up, run `pipenv run tim -u localhost ping`.
 ### OpenSearch on AWS
 
 1. Ensure that you have the correct AWS credentials set for the Dev1 (or desired) account.
-2. Set the `OPENSEARCH_ENDPOINT` variable in your .env to match the Dev1 (or desired) TIMDEX OpenSearch endpoint (note: do not include the http scheme prefix).
+2. Set the `TIMDEX_OPENSEARCH_ENDPOINT` variable in your .env to match the Dev1 (or desired) TIMDEX OpenSearch endpoint (note: do not include the http scheme prefix).
 3. Run `pipenv run tim ping` to confirm the client is connected to the expected TIMDEX OpenSearch instance.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ def test_env():
         "AWS_ACCESS_KEY_ID": "test",
         "AWS_SECRET_ACCESS_KEY": "test",
         "AWS_SESSION_TOKEN": "test",
-        "OPENSEARCH_ENDPOINT": "localhost",
+        "TIMDEX_OPENSEARCH_ENDPOINT": "localhost",
         "SENTRY_DSN": None,
         "WORKSPACE": "test",
     }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,7 +17,7 @@ def escape_ansi(line):
 def test_main_group_no_options_configures_correctly_and_invokes_result_callback(
     caplog, monkeypatch, runner
 ):
-    monkeypatch.delenv("OPENSEARCH_ENDPOINT", raising=False)
+    monkeypatch.delenv("TIMDEX_OPENSEARCH_ENDPOINT", raising=False)
     result = runner.invoke(main, ["ping"])
     assert result.exit_code == 0
     assert "Logger 'root' configured with level=INFO" in caplog.text
@@ -29,7 +29,7 @@ def test_main_group_no_options_configures_correctly_and_invokes_result_callback(
 def test_main_group_all_options_configures_correctly_and_invokes_result_callback(
     caplog, monkeypatch, runner
 ):
-    monkeypatch.delenv("OPENSEARCH_ENDPOINT", raising=False)
+    monkeypatch.delenv("TIMDEX_OPENSEARCH_ENDPOINT", raising=False)
     result = runner.invoke(main, ["--verbose", "--url", "localhost", "ping"])
     assert result.exit_code == 0
     assert "Logger 'root' configured with level=DEBUG" in caplog.text

--- a/tim/cli.py
+++ b/tim/cli.py
@@ -36,12 +36,12 @@ click.rich_click.COMMAND_GROUPS = {
 @click.option(
     "-u",
     "--url",
-    envvar="OPENSEARCH_ENDPOINT",
+    envvar="TIMDEX_OPENSEARCH_ENDPOINT",
     default="localhost",
     help="The OpenSearch instance endpoint minus the http scheme, e.g. "
     "'search-timdex-env-1234567890.us-east-1.es.amazonaws.com'. If not provided, will "
-    "attempt to get from the OPENSEARCH_ENDPOINT environment variable. Defaults to "
-    "'localhost'.",
+    "attempt to get from the TIMDEX_OPENSEARCH_ENDPOINT environment variable. Defaults "
+    "to 'localhost'.",
 )
 @click.option(
     "-v", "--verbose", is_flag=True, help="Pass to log at debug level instead of info"


### PR DESCRIPTION
### What does this PR do?

The ENV variable name for the OpenSearch endpoint has been changed in Terraform to match the name formatting for other TIMDEX ENV variables, so the code here needs to change as well. This PR updates the ENV variable name from `OPENSEARCH_ENDPOINT` to `TIMDEX_OPENSEARCH_ENDPOINT` across the repo, including in the README.

### Includes new or updated dependencies?

NO

### Developer

- [x] All new ENV is documented in README (or there is none)
- [x] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer

- [ ] The commit message is clear and follows our guidelines (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes