### PR TITLE
Adds debug console cli command

### DIFF
--- a/tim/cli.py
+++ b/tim/cli.py
@@ -352,3 +352,20 @@ def bulk_delete(
         results["deleted"],
         results["total"],
     )
+
+
+@main.command()
+@click.pass_context
+def console(ctx: click.Context) -> None:
+    """Open a debug console where you can run arbitrary commands.
+
+    You will have a `client` and can run commands such as dir(client) to
+    understand what methods are available. Another example is to list all
+    shards via `client.cat.shards('all-current')`.
+
+    This is meant for interactive development and debugging work, not as a
+    replacement for building out essential tim_os features.
+    """
+    client = ctx.obj["CLIENT"]
+    click.echo("Entering debug console. Exit by typing `c` then `enter`")
+    tim_os.console(client)

--- a/tim/opensearch.py
+++ b/tim/opensearch.py
@@ -407,3 +407,19 @@ def bulk_index(
     )
     logger.debug(response)
     return result
+
+# Debug Console functions
+
+
+def console(client: OpenSearch) -> None:
+    """Open a debug console where you can run arbitrary commands.
+
+    This is useful as tim_os handles the aws connection information to simplify
+    the process of credentialling in the event we need to use features not yet
+    built into tim_os.
+    """
+    logger.debug("Entering debug mode with client '%s'", client)
+
+    import pdb
+
+    pdb.set_trace()


### PR DESCRIPTION
This is intended as more of a discussion of how we might find a way to introduce this type of functionality but this is NOT how we'd likely want to actually introduce it. It is super useful and I'm not sure yet how to make it as useful as this without doing possibly dumb things to make it work.

So firstly: is there agreement that this is a useful feature (setting aside how it was actually implemented and whether it's a bad idea or the worst idea ever).

If so: do we have ideas on how to make this type of feature?

Why are these changes being introduced:

* tim_os will never have all of the features of the opensearch client library
* accessing opensearch in aws is a pain due to the v4 signing without using a client

How does this address that need:

* Create a CLI option that drops you into a debugger with a client preconfigured for your connection

Document any side effects to this change:

* this loads the pdb debugger into production code which is not ideal

### Includes new or updated dependencies?

YES (pdb which is not a good idea)

### Developer

- [x] All new ENV is documented in README (or there is none)
- [x] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes
