### PR TITLE
Sets primary and replica shard counts

### DIFF
--- a/config/opensearch_mappings.json
+++ b/config/opensearch_mappings.json
@@ -1,5 +1,7 @@
 {
   "settings": {
+    "number_of_shards": 1,
+    "number_of_replicas": 1,
     "analysis": {
       "analyzer": {
         "keyword_no_trailing_punctuation": {


### PR DESCRIPTION
Why are these changes being introduced:

* AWS uses a default of 5 which is larger than our current and predicted data size indicates is appropriate for any single index

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/TIMX-187

How does this address that need:

* Sets the value of primary and replica shards to 1 for all indexes created via TIM by adding those values to our existing settings loader


### How can a reviewer manually see the effects of these changes?

* create a new index, then checkout the other branch that adds the display of values for primary and replica shards, then list the indexes (I wasn't sure what this work would look like or I would have combined the two PRs)


### Includes new or updated dependencies?

NO


### Developer

- [x] All new ENV is documented in README (or there is none)
- [x] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes
