### PR TITLE
Update geopoint to geoshape

### DIFF
--- a/config/opensearch_mappings.json
+++ b/config/opensearch_mappings.json
@@ -257,10 +257,9 @@
       },
       "locations": {
         "type": "nested",
-        "include_in_parent": "true",
         "properties": {
-          "geopoint": {
-            "type": "geo_point"
+          "geoshape": {
+            "type": "geo_shape"
           },
           "kind": {
             "type": "keyword",

--- a/config/opensearch_mappings.json
+++ b/config/opensearch_mappings.json
@@ -257,9 +257,11 @@
       },
       "locations": {
         "type": "nested",
+        "include_in_parent": "true",
         "properties": {
           "geoshape": {
-            "type": "geo_shape"
+            "type": "geo_shape",
+            "doc_values": "false"
           },
           "kind": {
             "type": "keyword",


### PR DESCRIPTION
### Helpful background context
While testing the updated mapping, we ran into an OpenSearch error when a record could not be ingested if it contained more than one `geo_shape` type. This caused issues because we mapped both `dcat_bbox` and `locn_geometry` to `Location.geoshape`, which is ingested as an OpenSearch `geo_shape` type. While MIT records do not have different values for these fields, we have already found examples in OGM records where the fields differ and we would prefer not to lose those unique values.

We discovered that removing `include_in_parent` property allowed us to successfully index the records. @jprevost This has obvious implications for the GraphQL queries so we wanted to get your input and approval before proceeding with this change.

### How can a reviewer manually see the effects of these changes?
Ensure that `TIMDEX_OPENSEARCH_ENDPOINT` is not set as an env var and spin up a local Docker container with:
```
docker run -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -e "plugins.security.disabled=true" opensearchproject/opensearch:2.11.0
```
In new terminal window, create a new `gismit` index:
```
pipenv run tim create -s gismit
```
Copy the index name and promote the index to the `gismit` alias:
```
pipenv run tim promote -a gismit -i <index name>
```

Set `Dev1` credentials and `bulk-index` the following S3 file with `Location.geoshape` to see that it successfully indexes:
```
pipenv run tim bulk-index -s gismit s3://timdex-extract-dev-222053980223/gismit/gismit.json
```
### Includes new or updated dependencies?
NO

### What are the relevant tickets?
* https://mitlibraries.atlassian.net/browse/GDT-116

### Developer
- [x] All new ENV is documented in README (or there is none)
- [x] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer
- [ ] The commit message is clear and follows our guidelines (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes
