### PR TITLE
Adds docker compose and info on using dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,26 @@ A local OpenSearch instance can be started for development purposes by running:
 ``` bash
 $ docker run -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" \
   -e "plugins.security.disabled=true" \
-  opensearchproject/opensearch:2.3.0
+  opensearchproject/opensearch:2.11.1
 ```
 
 To confirm the instance is up, run `pipenv run tim -u localhost ping`.
+
+Alternately, you can use the included Docker Compose file to start an OpenSearch node along with an OpenSearch Dashboard. This should leave you with the same
+
+```bash
+docker pull opensearchproject/opensearch:latest
+docker pull opensearchproject/opensearch-dashboards:latest
+docker compose up
+```
+
+To confirm the instance is up, run `pipenv run tim -u localhost ping`.
+
+To access the Dashboard, access <http://localhost:5601>.
+
+DevTools is useful for writing/testing OpenSearch queries.
+
+Discover is useful for browsing data. An index pattern will be required to use this tool. Note: do not set a date filed (choose the option to skip selecting a date field). It detects a date field in our indexes but then crashes trying to use it. Once you skip the data select field, just enter an index or alias to pull patterns from and it will automatically be configured to work well enough for initial data exploration.
 
 ### OpenSearch on AWS
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,30 @@
+version: "3.8"
+services:
+  opensearch:
+    image: opensearchproject/opensearch:latest
+    ports:
+      - "9200:9200"
+      - "9600:9600"
+    environment:
+      - plugins.security.disabled=true
+      - discovery.type=single-node
+      - bootstrap.memory_lock=true
+      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
+    volumes:
+      - opensearch-local-data:/usr/share/opensearch/data
+    networks:
+      - opensearch-local-net
+  dashboard:
+    image: opensearchproject/opensearch-dashboards:latest
+    ports:
+      - "5601:5601"
+    environment:
+      - "DISABLE_SECURITY_DASHBOARDS_PLUGIN=true"
+      - 'OPENSEARCH_HOSTS=["http://opensearch:9200"]'
+    networks:
+      - opensearch-local-net
+volumes:
+  opensearch-local-data:
+
+networks:
+  opensearch-local-net:


### PR DESCRIPTION
Why are these changes being introduced:

* OpenSearch Dashboards are a super useful local development tool

How does this address that need:

* Adds a compose.yaml file that includes a single opensearch node along with a opensearch dashboard
* Security is disabled making this only intended for development use

Document any side effects to this change:

* We may want to consider only documenting the usage of `docker compose up` rather than having the one-off commands to spin up OpenSearch, but I'm not sure if everyone will prefer this so for now I have left the previous instructions in place. If we find we prefer this in the future we can remove the non compose instructions.

### How can a reviewer manually see the effects of these changes?

Follow the new instructions added in the readme to create an OpenSearch node and Dashboard via compose.

Confirm you can interact with this OpenSearch in the same way you could previously interact with he instance created
via the non-compose readme instructions.

Confirm you can access the dashboard and run opensearch queries via DevTools and/or can create an index pattern and browse the data via Discover

### Includes new or updated dependencies?

NO

### Developer

- [x] All new ENV is documented in README (or there is none)
- [x] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer

- [x] The commit message is clear and follows our guidelines (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes
