### PR TITLE
Support 'opensearch' as local host variation

### DIFF
--- a/tests/test_opensearch.py
+++ b/tests/test_opensearch.py
@@ -25,6 +25,11 @@ def test_configure_opensearch_client_for_localhost():
     assert str(result) == "<OpenSearch([{'host': 'localhost', 'port': '9200'}])>"
 
 
+def test_configure_opensearch_client_for_local_opensearch_host():
+    result = tim_os.configure_opensearch_client("opensearch")
+    assert str(result) == "<OpenSearch([{'host': 'opensearch', 'port': '9200'}])>"
+
+
 @mock.patch("boto3.session.Session")
 def test_configure_opensearch_client_for_aws(mocked_boto3_session):  # noqa
     result = tim_os.configure_opensearch_client("fake-dev.us-east-1.es.amazonaws.com")

--- a/tim/opensearch.py
+++ b/tim/opensearch.py
@@ -34,7 +34,7 @@ def configure_opensearch_client(url: str) -> OpenSearch:
     Includes the appropriate AWS credentials configuration if the URL is not localhost.
     """
     logger.info("OpenSearch request configurations: %s", REQUEST_CONFIG)
-    if url == "localhost":
+    if url in ["localhost", "opensearch"]:
         return OpenSearch(
             hosts=[{"host": url, "port": "9200"}],
             http_auth=("admin", "admin"),


### PR DESCRIPTION
### What does this PR do?

This PR allows setting `TIMDEX_OPENSEARCH_ENDPOINT="opensearch"` while still triggering the local connection code path, setting up a connection to Opensearch without SSL, no authentication, looking for the running Opensearch instance on host/port `opensearch:9200`.

As long as a container running Opensearch and this TIM container share a docker network (e.g. `timdex-index-manager_opensearch-local-net` which the new docker compose file sets), this TIM project can reach Opensearch by using the connection host `opensearch:9200`.

### Helpful background context

Previously, only the string `localhost` (or omitting setting `TIMDEX_OPENSEARCH_ENDPOINT`) would trigger the code path to setup an Opensearch connection to a locally running instance.  This proved problematic when attempting to have a docker container (e.g. this TIM application) connect to _another_ docker container (e.g. an Opensearch instance) because `localhost` was pointing at the calling TIM container and could not see the other.  Setting `network_mode="host"` did not work either, as the TIM container still could not reach the other docker container running Opensearch.

### How can a reviewer manually see the effects of these changes?

1- Build a local docker container for TIM:
```shell
make dist-dev
```

2- Run Opensearch locally,:
```shell
docker compose up
```

Note that this creates a docker network called `timdex-index-manager_opensearch-local-net` based on the directory name + network name set in the compose file:
```text
[+] Running 4/4
 ✔ Network timdex-index-manager_opensearch-local-net    Created  <--------------------------
 ✔ Volume "timdex-index-manager_opensearch-local-data"  Created
 ✔ Container timdex-index-manager-opensearch-1          Created
 ✔ Container timdex-index-manager-dashboard-1           Created
```

3- Invoke TIM via a docker container, setting the env var `TIMDEX_OPENSEARCH_ENDPOINT="opensearch"` and docker network name, and confirm that it makes a successful request to a locally running Opensearch instance by way of the `opensearch` host:
```shell
docker run \
-e "TIMDEX_OPENSEARCH_ENDPOINT=opensearch" \
--network "timdex-index-manager_opensearch-local-net" \
timdex-index-manager-dev:latest \
ping
```

Expected output:
```
2024-01-23 15:08:58,251 INFO tim.cli.main(): Logger 'root' configured with level=INFO
2024-01-23 15:08:58,252 INFO tim.cli.main(): No Sentry DSN found, exceptions will not be sent to Sentry
2024-01-23 15:08:58,252 INFO tim.opensearch.configure_opensearch_client(): OpenSearch request configurations: {'OPENSEARCH_BULK_MAX_CHUNK_BYTES': 104857600, 'OPENSEARCH_BULK_MAX_RETRIES': 50, 'OPENSEARCH_REQUEST_TIMEOUT': 120}
2024-01-23 15:08:58,253 INFO tim.cli.main(): OpenSearch client configured for endpoint 'opensearch'

Name: docker-cluster
UUID: J3QlOm1iQLGI33ziudU0nQ
OpenSearch version: 2.11.1
Lucene version: 9.7.0

2024-01-23 15:08:58,287 INFO tim.cli.log_process_time(): Total time to complete process: 0:00:00.035351
```

### Includes new or updated dependencies?

NO

### What are the relevant tickets?

None

### Developer

- [X] All new ENV is documented in README (or there is none)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer

- [ ] The commit message is clear and follows our guidelines (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes
