### PR TITLE
USE 373 - reduce TIM bulk update logging

### DIFF
--- a/tim/config.py
+++ b/tim/config.py
@@ -5,7 +5,7 @@ import os
 import sentry_sdk
 
 OPENSEARCH_BULK_CONFIG_DEFAULTS = {
-    "OPENSEARCH_BULK_MAX_CHUNK_BYTES": 100 * 1024 * 1024,
+    "OPENSEARCH_BULK_MAX_CHUNK_BYTES": 20 * 1024 * 1024,
     "OPENSEARCH_BULK_MAX_RETRIES": 50,
     "OPENSEARCH_REQUEST_TIMEOUT": 120,
 }
@@ -41,7 +41,7 @@ def configure_logger(
     """Configure application via passed application root logger.
 
     If verbose=True, 3rd party libraries can be quite chatty.  For convenience, they can
-    be set to WARNING level by either passing a comma seperated list of logger names to
+    be set to WARNING level by either passing a comma separated list of logger names to
     'warning_only_loggers' or by setting the env var WARNING_ONLY_LOGGERS.
     """
     if verbose:
@@ -50,6 +50,14 @@ def configure_logger(
             "%(asctime)s %(levelname)s %(name)s.%(funcName)s() "
             "line %(lineno)d: %(message)s"
         )
+
+        # Explicitly filter out opensearchpy's DEBUG logging of all API request payloads.
+        # This private method logs both the request + response payloads.  If we need to
+        # know, we can both log data sent (request) or received (response).
+        logging.getLogger("opensearch").addFilter(
+            lambda record: record.funcName != "_log_request_response"
+        )
+
     else:
         root_logger.setLevel(logging.INFO)
         logging_format = "%(asctime)s %(levelname)s %(name)s.%(funcName)s(): %(message)s"

--- a/uv.lock
+++ b/uv.lock
@@ -40,43 +40,43 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.42.63"
+version = "1.42.65"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7f/2a/33d5d4b16fd97dfd629421ebed2456392eae1553cc401d9f86010c18065e/boto3-1.42.63.tar.gz", hash = "sha256:cd008cfd0d7ea30f1c5e22daf0998c55b7c6c68cb68eea05110e33fe641173d5", size = 112778, upload-time = "2026-03-06T22:47:55.96Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/c9/8ff8a901cf62374f1289cf36391f855e1702c70f545c28d1b57608a84ff2/boto3-1.42.65.tar.gz", hash = "sha256:c740af6bdaebcc1a00f3827a5729050bf6fc820ee148bf7d06f28db11c80e2a1", size = 112805, upload-time = "2026-03-10T19:44:58.255Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/19/f1d8d2b24871d3d0ccb2cbd0b0cb64a3396d439384bd9643d2c25c641b84/boto3-1.42.63-py3-none-any.whl", hash = "sha256:d502a89a0acc701692ae020d15981f2a82e9eb3485acc651cfd0cf1a3afe79ee", size = 140554, upload-time = "2026-03-06T22:47:53.463Z" },
+    { url = "https://files.pythonhosted.org/packages/46/bb/ace5921655df51e3c9b787b3f0bd6aa25548e5cf1dabae02e53fa88f2d98/boto3-1.42.65-py3-none-any.whl", hash = "sha256:cc7f2e0aec6c68ee5b10232cf3e01326acf6100bc785a770385b61a0474b31f4", size = 140556, upload-time = "2026-03-10T19:44:55.433Z" },
 ]
 
 [[package]]
 name = "boto3-stubs"
-version = "1.42.63"
+version = "1.42.65"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore-stubs" },
     { name = "types-s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/83/30/45d21d3df4598b6b37d8de9923603010e490dfc73a130c8ffa806750b1ff/boto3_stubs-1.42.63.tar.gz", hash = "sha256:b64726c86c0b3efbc6ccd4f0510fa5a8279caec46da36a91c037a4b395001e68", size = 101176, upload-time = "2026-03-06T22:50:00.514Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/a4/ff83514d9ce6750d497aba084f4e2c1e053d9a91770da32eaadd68fa4379/boto3_stubs-1.42.65.tar.gz", hash = "sha256:013bcb1f03bf8689d53ef24c2da5ce430a3a298813fdfc24ea81caca937952c1", size = 101190, upload-time = "2026-03-10T20:01:56.228Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/c2/933ecf99d0cc1ae1b463086d203b27a29ba05c1d1cdd8a3efb18bc1e8c98/boto3_stubs-1.42.63-py3-none-any.whl", hash = "sha256:132e9c57bfef5ea943745d6cdad16e62d4e82dca64f6ae9ddfba9789fcdc8378", size = 69913, upload-time = "2026-03-06T22:49:49.765Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/63/d215d55c0b6f2d6ab496ecd55397e8c153389382254434fd57abf4e3d95e/boto3_stubs-1.42.65-py3-none-any.whl", hash = "sha256:69b5a27619f1a9cfe0d895a1d7921f1a25c5101cdac52fa59463d79e0e25b472", size = 69917, upload-time = "2026-03-10T20:01:42.718Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.42.63"
+version = "1.42.65"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/eb/a1c042f6638ada552399a9977335a6de2668a85bf80bece193c953531236/botocore-1.42.63.tar.gz", hash = "sha256:1fdfc33cff58d21e8622cf620ba2bba3cff324557932aaf935b5374e4610f059", size = 14965362, upload-time = "2026-03-06T22:47:44.158Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/81/2c832e2117d24da4fe800861e8ddd19bbaa308623b1198eb2c2cc6fcd3d4/botocore-1.42.65.tar.gz", hash = "sha256:7d52c148df07f70c375eeda58f99b439c7c7836c25df74cccfba3bb6e12444d2", size = 14970239, upload-time = "2026-03-10T19:44:43.686Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/60/17a2d3b94658bb999c6aee7bba6c76b271905debf0c8c8e6ac63ca8491bc/botocore-1.42.63-py3-none-any.whl", hash = "sha256:83f39d04f2b316bdfc59a3cac2d12238bde7126ac99d9a57d910dbd86d58c528", size = 14639889, upload-time = "2026-03-06T22:47:39.347Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/9e/2ca03a55408c0820d7f0a04ae52bc6dfc7e4fff1f007a90135a68e056c93/botocore-1.42.65-py3-none-any.whl", hash = "sha256:0283c332ce00cbd1b894e86b7bed89dd624a5ca3a4ee62ec4db3898d16652e98", size = 14644794, upload-time = "2026-03-10T19:44:37.442Z" },
 ]
 
 [[package]]
@@ -369,11 +369,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.25.0"
+version = "3.25.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/77/18/a1fd2231c679dcb9726204645721b12498aeac28e1ad0601038f94b42556/filelock-3.25.0.tar.gz", hash = "sha256:8f00faf3abf9dc730a1ffe9c354ae5c04e079ab7d3a683b7c32da5dd05f26af3", size = 40158, upload-time = "2026-03-01T15:08:45.916Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/8b/4c32ecde6bea6486a2a5d05340e695174351ff6b06cf651a74c005f9df00/filelock-3.25.1.tar.gz", hash = "sha256:b9a2e977f794ef94d77cdf7d27129ac648a61f585bff3ca24630c1629f701aa9", size = 40319, upload-time = "2026-03-09T19:38:47.309Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/0b/de6f54d4a8bedfe8645c41497f3c18d749f0bd3218170c667bf4b81d0cdd/filelock-3.25.0-py3-none-any.whl", hash = "sha256:5ccf8069f7948f494968fc0713c10e5c182a9c9d9eef3a636307a20c2490f047", size = 26427, upload-time = "2026-03-01T15:08:44.593Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/b8/2f664b56a3b4b32d28d3d106c71783073f712ba43ff6d34b9ea0ce36dc7b/filelock-3.25.1-py3-none-any.whl", hash = "sha256:18972df45473c4aa2c7921b609ee9ca4925910cc3a0fb226c96b92fc224ef7bf", size = 26720, upload-time = "2026-03-09T19:38:45.718Z" },
 ]
 
 [[package]]
@@ -1093,15 +1093,15 @@ wheels = [
 
 [[package]]
 name = "python-discovery"
-version = "1.1.1"
+version = "1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ec/67/09765eacf4e44413c4f8943ba5a317fcb9c7b447c3b8b0b7fce7e3090b0b/python_discovery-1.1.1.tar.gz", hash = "sha256:584c08b141c5b7029f206b4e8b78b1a1764b22121e21519b89dec56936e95b0a", size = 56016, upload-time = "2026-03-07T00:00:56.354Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/7e/9f3b0dd3a074a6c3e1e79f35e465b1f2ee4b262d619de00cfce523cc9b24/python_discovery-1.1.3.tar.gz", hash = "sha256:7acca36e818cd88e9b2ba03e045ad7e93e1713e29c6bbfba5d90202310b7baa5", size = 56945, upload-time = "2026-03-10T15:08:15.038Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/0f/2bf7e3b5a4a65f623cb820feb5793e243fad58ae561015ee15a6152f67a2/python_discovery-1.1.1-py3-none-any.whl", hash = "sha256:69f11073fa2392251e405d4e847d60ffffd25fd762a0dc4d1a7d6b9c3f79f1a3", size = 30732, upload-time = "2026-03-07T00:00:55.143Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/80/73211fc5bfbfc562369b4aa61dc1e4bf07dc7b34df7b317e4539316b809c/python_discovery-1.1.3-py3-none-any.whl", hash = "sha256:90e795f0121bc84572e737c9aa9966311b9fde44ffb88a5953b3ec9b31c6945e", size = 31485, upload-time = "2026-03-10T15:08:13.06Z" },
 ]
 
 [[package]]
@@ -1322,8 +1322,8 @@ wheels = [
 
 [[package]]
 name = "timdex-dataset-api"
-version = "3.11.0"
-source = { git = "https://github.com/MITLibraries/timdex-dataset-api.git#4cf98a4cb135596652130959644dd9c7b16f115b" }
+version = "4.0.0"
+source = { git = "https://github.com/MITLibraries/timdex-dataset-api.git#d58eccec67a2e1451d1c7f3c44846e07ccc311fb" }
 dependencies = [
     { name = "attrs" },
     { name = "boto3" },
@@ -1518,7 +1518,7 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "21.1.0"
+version = "21.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
@@ -1526,9 +1526,9 @@ dependencies = [
     { name = "platformdirs" },
     { name = "python-discovery" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/c9/18d4b36606d6091844daa3bd93cf7dc78e6f5da21d9f21d06c221104b684/virtualenv-21.1.0.tar.gz", hash = "sha256:1990a0188c8f16b6b9cf65c9183049007375b26aad415514d377ccacf1e4fb44", size = 5840471, upload-time = "2026-02-27T08:49:29.702Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/92/58199fe10049f9703c2666e809c4f686c54ef0a68b0f6afccf518c0b1eb9/virtualenv-21.2.0.tar.gz", hash = "sha256:1720dc3a62ef5b443092e3f499228599045d7fea4c79199770499df8becf9098", size = 5840618, upload-time = "2026-03-09T17:24:38.013Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/55/896b06bf93a49bec0f4ae2a6f1ed12bd05c8860744ac3a70eda041064e4d/virtualenv-21.1.0-py3-none-any.whl", hash = "sha256:164f5e14c5587d170cf98e60378eb91ea35bf037be313811905d3a24ea33cc07", size = 5825072, upload-time = "2026-02-27T08:49:27.516Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/59/7d02447a55b2e55755011a647479041bc92a82e143f96a8195cb33bd0a1c/virtualenv-21.2.0-py3-none-any.whl", hash = "sha256:1bd755b504931164a5a496d217c014d098426cddc79363ad66ac78125f9d908f", size = 5825084, upload-time = "2026-03-09T17:24:35.378Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Purpose and background context

This PR dramatically reduces `DEBUG` logging for TIM for bulk updates.  

`DEBUG` logging is very helpful sometimes, potentially ever for large jobs, and much of the `opensearch` logging is very helpful and informative.  It does have one _very_ chatty logging statement that is problematic: `opensearch.base._log_request_response()`.  This logs both the API request + response.  For bulk indexing and updating we are sending tons of data -- the TIMDEX records to index/update -- and they are all logged when in `DEBUG` mode.

This may seem inconsequential for a few hundred records, but as we get into larger runs (thousands, millions?), the amount of data logged >= the amount of data we sent!

This PR filters out only this specific method from logging.  If we need to know what data we send or receieve from an API request, we can do so; this `opensearchpy` library logging line feels superfluous.

### How can a reviewer manually see the effects of these changes?

Easier to just share logs before after the change.

Here is a snippet pre-changes, showing how each record we send for update is getting logged:

```text
2026-03-12 14:42:07,218 DEBUG urllib3.connectionpool._make_request() line 544: http://localhost:9200 "POST /_bulk HTTP/1.1" 200 60086
2026-03-12 14:42:07,219 INFO opensearch.log_request_success() line 258: POST http://localhost:9200/_bulk [status:200 request:0.597s]
2026-03-12 14:42:07,221 DEBUG opensearch._log_request_response() line 197: > {"update":{"_id":"libguides:guides-886887","_index":"libguides-2026-03-12t17-15-16"}}
{"doc":{"timdex_record_id":"libguides:guides-886887","embedding_full_record":{"living":0.8538653254508972,"guide":0.740427553653717,"mit":0.6558040380477905,"machine":0.6258775591850281,"machines":0.56385737657547,"guides":0.5570834875106812,"tim":0.5311638116836548,"##de":0.5261822938919067,"library":0.5066640973091125,"##guide":0.4877738058567047,"li":0.47927117347717285,"biotechnology":0.47543856501579285,"citation":0.46380311250686646,"cite":0.44210368394851685,"research":0.42463016510009766,"id":0.4221096634864807,"citations":0.40657997131347656,"##b":0.39701151847839355,"pm":0.38286277651786804,"offset":0.38262689113616943,"libraries":0.3813073933124542,"course":0.37452349066734314,"biology":0.36781901121139526,"resources":0.3584938645362854,"value":0.355313777923584,"source":0.35052841901779175,"date":0.34472012519836426,"o":0.3440041244029999,"cited":0.34011706709861755,"format":0.3398839831352234,"machinery":0.33851370215415955,"resource":0.332459032535553,"scheme":0.3157486617565155,"courses":0.3049998879432678,"manual":0.3034125566482544,"##ance":0.3025076389312744,"engineering":0.3023518919944763,"##x":0.30020377039909363,"reference":0.29680877923965454,"proven":0.29633891582489014,"run":0.28933703899383545,"88":0.27989187836647034,"electronic":0.27825620770454407,"ur":0.2681453824043274,"robot":0.2634217143058777,"librarian":0.2600238025188446,"code":0.2585568428039551,"robots":0.2561008930206299,"university":0.24649527668952942,"biological":0.24346278607845306,"science":0.23967169225215912,"record":0.23632432520389557,"subject":0.23530788719654083,"bibliography":0.23463675379753113,"software":0.23040013015270233,"guidelines":0.22408396005630493,"biomedical":0.22396573424339294,"bio":0.2211754471063614,"##tech":0.22110611200332642,"publisher":0.21981856226921082,"device":0.21592196822166443,"publication":0.21378153562545776,"booklet":0.21230173110961914,"published":0.20655468106269836,"ebook":0.20392538607120514,"##des":0.19879622757434845,"citing":0.1959264874458313,"link":0.19579347968101501,"diagram":0.19409768283367157,"repository":0.19315005838871002,"database":0.1864480972290039,"##mac":0.1845746487379074,"content":0.18202728033065796,"copyright":0.18079324066638947,"textbooks":0.18015064299106598,"life":0.17860212922096252,"robotics":0.17161503434181213,"##hine":0.17064021527767181,"computer":0.16853807866573334,"publishing":0.16623876988887787,"timothy":0.165269672870636,"referenced":0.1583074927330017,"file":0.15769585967063904,"automated":0.15258172154426575,"kind":0.15170568227767944,"curriculum":0.15102751553058624,"documentation":0.1509629189968109,"books":0.14879107475280762,"cart":0.14607824385166168,"version":0.14479020237922668,"##s":0.14474940299987793,"created":0.14448769390583038,"computers":0.14288991689682007,"referencing":0.13915526866912842,"records":0.13860684633255005,"links":0.13366806507110596,"medicine":0.13145631551742554,"title":0.13021227717399597,"number":0.12847627699375153,"automation":0.12676239013671875,"189":0.12584373354911804,"alive":0.12210410833358765,"schemes":0.12056668102741241,"computing":0.11826060712337494,"##ai":0.11438414454460144,"robotic":0.11298719793558121,"summary":0.1100582405924797,"institute":0.10678854584693909,"book":0.10667821764945984,"scientific":0.10269121080636978,"##mata":0.09981551021337509,"liv":0.0995909571647644,"wiley":0.09914477169513702,"topic":0.09833987057209015,"live":0.09790042787790298,"##kit":0.0966830849647522,"mach":0.09642475098371506,"tools":0.09610056132078171,"mechanical":0.09574735909700394,"micro":0.09550879150629044,"ed":0.09068247675895691,"appliances":0.09021327644586563,"edition":0.08983706682920456,"##ded":0.08928465843200684,"textbook":0.08890774846076965,"document":0.08705782145261765,"##8":0.08678745478391647,"simulator":0.08607867360115051,"classes":0.08523360639810562,"20":0.08490162342786789,"laptop":0.08276581764221191,"hardware":0.07753424346446991,"##bio":0.077327199280262,"medical":0.07537329196929932,"ai":0.07421056926250458,"find":0.0718519389629364,"##52":0.07160057872533798,"references":0.07000301033258438,"text":0.06927108764648438,"identification":0.0679425597190857,"_":0.06763697415590286,"catalog":0.06667140126228333,"license":0.06481201946735382,"##bs":0.061491984874010086,"##bot":0.06116531416773796,"##ifier":0.06086268275976181,"sources":0.05935549736022949,"pdf":0.05851719528436661,"website":0.058071572333574295,"##u":0.057393163442611694,"journal":0.057318542152643204,"api":0.05601394549012184,"study":0.05538337305188179,"project":0.05479412153363228,"computational":0.05476228520274162,"odi":0.054527197033166885,"eds":0.05392998456954956,"wikipedia":0.05284207686781883,"cambridge":0.05101117119193077,"massachusetts":0.050758857280015945,"web":0.050668735057115555,"##rri":0.050201721489429474,"class":0.04828942194581032,"##lib":0.04740864038467407,"simulation":0.045844025909900665,"guidance":0.045092854648828506,"publishers":0.044306620955467224,"valid":0.04209505766630173,"sci":0.04127785190939903,"##da":0.04124832898378372,"program":0.04065992683172226,"handbook":0.03850552439689636,"formats":0.037345536053180695,"##bt":0.03406350314617157,"sourced":0.03349665179848671,"publish":0.03348272293806076,"domain":0.03216037154197693,"##l":0.030183663591742516,"foreman":0.030098900198936462,"specification":0.029504097998142242,"proof":0.029461929574608803,"pub":0.029098009690642357,"tractors":0.028967007994651794,"tool":0.02849779650568962,"thesis":0.027857426553964615,"##be":0.027813266962766647,"b":0.026587948203086853,"##ances":0.025388024747371674,"technology":0.024891451001167297,"php":0.02448941208422184,"education":0.022896897047758102,"##bi":0.022638052701950073,"type":0.020342659205198288,"verified":0.019134189933538437,"python":0.017602723091840744,"topics":0.016866177320480347,"#":0.015982864424586296,"modular":0.015169109217822552,"engineer":0.014628314413130283,"##omics":0.01267132069915533,"patent":0.01136673241853714,"##du":0.009110997430980206,"proprietary":0.008144748397171497,"college":0.007056851405650377,"password":0.00636832183226943,"mechanics":0.0015023105079308152,"subjects":0.000857065140735358,"202":0.0006539863534271717}}}
{"update":{"_id":"libguides:guides-175847","_index":"libguides-2026-03-12t17-15-16"}}
{"doc":{"timdex_record_id":"libguides:guides-175847","embedding_full_record":{"guide":0.7244652509689331,"mit":0.7116156220436096,"nt":0.6983522772789001,"library":0.5982416868209839,"guides":0.5822792053222656,"report":0.5552945137023926,"reports":0.5537885427474976,"##guide":0.5172713994979858,"tim":0.5149623155593872,"o":0.5015209317207336,"citation":0.4777209162712097,"li":0.472740113735199,"cite":0.47096869349479675,"research":0.4573235809803009,"aeronautics":0.45050203800201416,"id":0.44618692994117737,"##de":0.44281521439552307,"1758":0.4424474239349365,"tools":0.434268593788147,"##b":0.4337747097015381,"libraries":0.4282265305519104,"date":0.4201880097389221,"citations":0.41407427191734314,"astronaut":0.40737614035606384,"##sb":0.40674832463264465,"source":0.3975667953491211,"pm":0.3909572660923004,"format":0.38881054520606995,"##47":0.38085660338401794,"offset":0.37900596857070923,"cited":0.375982403755188,"ur":0.372848778963089,"librarian":0.35915136337280273,"tool":0.35191747546195984,"engineering":0.3435083031654358,"proven":0.3302948474884033,"reference":0.324806809425354,"scheme":0.31844043731689453,"##ance":0.3132529556751251,"resource":0.3129171133041382,"nasa":0.30834150314331055,"value":0.3061145842075348,"bibliography":0.291155070066452,"link":0.28447452187538147,"citing":0.2770882546901703,"run":0.2767525911331177,"aviation":0.2763192653656006,"electronic":0.269756942987442,"code":0.26523923873901367,"aerospace":0.2640654742717743,"php":0.26307493448257446,"astronauts":0.25952842831611633,"file":0.2592698931694031,"record":0.25646933913230896,"##s":0.2504093647003174,"database":0.2489977926015854,"##x":0.24705658853054047,"links":0.24188685417175293,"reporting":0.23295973241329193,"aeronautical":0.23187246918678284,"publisher":0.2314496487379074,"resources":0.2298468053340912,"manual":0.22644372284412384,"ns":0.22602999210357666,"university":0.22253966331481934,"repository":0.20797257125377655,"documentation":0.20442913472652435,"number":0.2014135867357254,"##46":0.20064114034175873,"diagram":0.19981718063354492,"publication":0.19747371971607208,"content":0.1967061460018158,"##cb":0.18530000746250153,"subject":0.18503227829933167,"guidelines":0.1780163198709488,"odi":0.17614606022834778,"referencing":0.1750677227973938,"software":0.17318417131900787,"##lib":0.1720639318227768,"booklet":0.17037472128868103,"summary":0.16881626844406128,"referenced":0.16861484944820404,"published":0.16606995463371277,"83":0.1592956930398941,"kind":0.15888839960098267,"ni":0.1585501730442047,"aircraft":0.15589407086372375,"records":0.15194863080978394,"schemes":0.15173183381557465,"created":0.1488443911075592,"space":0.14477111399173737,"journal":0.1403723806142807,"##ai":0.13809113204479218,"pub":0.1369464248418808,"astronomy":0.13585330545902252,"copyright":0.1342414915561676,"notes":0.13325431942939758,"web":0.1323285549879074,"c":0.13081173598766327,"references":0.1279386579990387,"##ics":0.12773679196834564,"publishing":0.12697939574718475,"##bs":0.12434622645378113,"version":0.12217514216899872,"text":0.1192815899848938,"sources":0.11749909818172455,"##l":0.11745239049196243,"nme":0.11734619736671448,"formats":0.1148650199174881,"type":0.11249425262212753,"catalog":0.10901553183794022,"identification":0.10816487669944763,"timothy":0.10807910561561584,"##be":0.10742628574371338,"handbook":0.10064920783042908,"faa":0.09494907408952713,"astro":0.09429772198200226,"sourced":0.09367470443248749,"orbital":0.09349511563777924,"document":0.09293197840452194,"##bt":0.09099604189395905,"##naut":0.09092023223638535,"_":0.09025603532791138,"stand":0.08944760262966156,"et":0.08548238128423691,"find":0.08226216584444046,"issn":0.08144427090883255,"website":0.07885904610157013,"#":0.074978306889534,"##24":0.07333523035049438,"nr":0.07170417904853821,"##38":0.06927315145730972,"ebook":0.06919620931148529,"title":0.06824342906475067,"stands":0.06805818527936935,"bulletin":0.06787524372339249,"linux":0.06713026762008667,"abbreviation":0.06642819941043854,"##u":0.06391729414463043,"api":0.0624709390103817,"files":0.061383746564388275,"topic":0.058295100927352905,"institute":0.05739588290452957,"books":0.05720850080251694,"47":0.056521929800510406,"n":0.05589563027024269,"ames":0.05490097776055336,"python":0.05322103202342987,"spacecraft":0.05289625748991966,"##des":0.051443688571453094,"bs":0.051066506654024124,"name":0.0497964583337307,"computer":0.04790725186467171,"##ifier":0.047680988907814026,"project":0.047473639249801636,"ed":0.046684250235557556,"valid":0.04574969410896301,"286":0.042662203311920166,"prefix":0.04197019338607788,"rocket":0.04094244912266731,"science":0.04047029837965965,"##ances":0.03942275047302246,"what":0.03719448298215866,"org":0.035926703363657,"book":0.03519910201430321,"##48":0.03220832347869873,"https":0.03134821355342865,"##bc":0.031128160655498505,"dates":0.030219383537769318,"password":0.029081596061587334,"archive":0.028072571381926537,"b":0.027637450024485588,"http":0.027600903064012527,"verified":0.025616681203246117,"prove":0.025263885036110878,"pdf":0.022440744563937187,"tag":0.02209603413939476,"access":0.02168360725045204,"wikipedia":0.020888589322566986,"sb":0.020794406533241272,"publishers":0.01946302503347397,"proof":0.018856685608625412,"domain":0.017308304086327553,"cites":0.017195861786603928,"aero":0.016874488443136215,"##44":0.01631942391395569,"string":0.01394092570990324,"202":0.01345987431704998,"##link":0.01257602870464325,"##bi":0.012096974067389965,"engineers":0.011414838023483753,"data":0.009160025976598263,"berkeley":0.00860415119677782,"##ent":0.00782522652298212,"retrieved":0.007272845599800348,"guidance":0.006858538370579481,"##ded":0.006612746976315975,"topics":0.005262910388410091,"java":0.004746489226818085,"publish":0.0026050566229969263,"engineer":0.0019652212504297495,"script":0.0014529762556776404,"pmid":0.0013679054100066423,"oracle":0.00113610306289047}}}
{"update":{"_id":"libguides:guides-175955","_index":"libguides-2026-03-12t17-15-16"}}
```

Here is the same section of logs, missing this particular private method logging:

```text
026-03-12 14:26:03,945 DEBUG urllib3.connectionpool._make_request() line 544: http://localhost:9200 "POST /_bulk HTTP/1.1" 200 60086
2026-03-12 14:26:03,946 INFO opensearch.log_request_success() line 258: POST http://localhost:9200/_bulk [status:200 request:0.455s]
# Gone!  🦗's
```

### Includes new or updated dependencies?
YES | NO

### Changes expectations for external applications?
YES | NO

### What are the relevant tickets?
- Include links to Jira Software and/or Jira Service Management tickets here.

### Code review
* Code review best practices are documented [here](https://mitlibraries.github.io/guides/collaboration/code_review.html) and you are encouraged to have a constructive dialogue with your reviewers about their preferences and expectations.