### PR TITLE
USE 559 - bulk update fulltexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,32 +151,34 @@ AUTH_SERVICE_TYPE=### Indicate instanced type for authentication, "es" (cluster)
 All CLI commands can be run with `uv run`. 
 
 ```
- Usage: tim [OPTIONS] COMMAND [ARGS]...                                                                                  
-                                                                                                                         
- TIM provides commands for interacting with OpenSearch indexes.                                                          
- For more details on a specific command, run tim COMMAND -h.                                                             
-                                                                                                                         
-╭─ Options ─────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ --url      -u  TEXT  The OpenSearch instance endpoint minus the http scheme, e.g.                                     │
-│                      'search-timdex-env-1234567890.us-east-1.es.amazonaws.com'. If not provided, will attempt to get  │
-│                      from the TIMDEX_OPENSEARCH_ENDPOINT environment variable. Defaults to 'localhost'.               │
-│ --verbose  -v        Pass to log at debug level instead of info                                                       │
-│ --help     -h        Show this message and exit.                                                                      │
-╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Get cluster-level information ───────────────────────────────────────────────────────────────────────────────────────╮
-│ ping           Ping OpenSearch and display information about the cluster.                                             │
-│ indexes        Display summary information about all indexes in the cluster.                                          │
-│ aliases        List OpenSearch aliases and their associated indexes.                                                  │
-╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Index management commands ───────────────────────────────────────────────────────────────────────────────────────────╮
-│ create      Create a new index in the cluster.                                                                        │
-│ delete      Delete an index.                                                                                          │
-│ promote     Promote index as the primary alias and add it to any additional provided aliases.                         │
-│ demote      Demote an index from all its associated aliases.                                                          │
-╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Bulk record processing commands ─────────────────────────────────────────────────────────────────────────────────────╮
-│ bulk-update          Bulk update records for an index.                                                                │
-│ reindex-source       Perform a full refresh for a source in Opensearch for all current records.                       │
-╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+ Usage: tim [OPTIONS] COMMAND [ARGS]...                                                                                 
+                                                                                                                        
+ TIM provides commands for interacting with OpenSearch indexes.                                                         
+ For more details on a specific command, run tim COMMAND -h.                                                            
+                                                                                                                        
+╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ --url      -u  TEXT  The OpenSearch instance endpoint minus the http scheme, e.g.                                    │
+│                      'search-timdex-env-1234567890.us-east-1.es.amazonaws.com'. If not provided, will attempt to get │
+│                      from the TIMDEX_OPENSEARCH_ENDPOINT environment variable. Defaults to 'localhost'.              │
+│ --verbose  -v        Pass to log at debug level instead of info                                                      │
+│ --help     -h        Show this message and exit.                                                                     │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Get cluster-level information ──────────────────────────────────────────────────────────────────────────────────────╮
+│ ping           Ping OpenSearch and display information about the cluster.                                            │
+│ indexes        Display summary information about all indexes in the cluster.                                         │
+│ aliases        List OpenSearch aliases and their associated indexes.                                                 │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Index management commands ──────────────────────────────────────────────────────────────────────────────────────────╮
+│ create      Create a new index in the cluster.                                                                       │
+│ delete      Delete an index.                                                                                         │
+│ promote     Promote index as the primary alias and add it to any additional provided aliases.                        │
+│ demote      Demote an index from all its associated aliases.                                                         │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Bulk record processing commands ────────────────────────────────────────────────────────────────────────────────────╮
+│ bulk-update                  Bulk update records for an index.                                                       │
+│ bulk-update-embeddings       Bulk update existing records with vector embeddings for an index.                       │
+│ bulk-update-fulltexts        Bulk update existing records with fulltexts for an index.                               │
+│ reindex-source               Perform a full refresh for a source in Opensearch for all current records.              │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "rich-click",
     "sentry-sdk",
     "smart-open[s3]",
-    "timdex-dataset-api @ git+https://github.com/MITLibraries/timdex-dataset-api.git",
+    "timdex-dataset-api",
 ]
 
 [dependency-groups]
@@ -103,3 +103,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.uv]
 package = true
+
+[tool.uv.sources]
+timdex-dataset-api = { git = "https://github.com/MITLibraries/timdex-dataset-api"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -372,6 +372,103 @@ def test_bulk_update_embeddings_source_only_logs_complete(
     )
 
 
+@pytest.mark.parametrize(
+    "bulk_update_return",
+    [
+        {"updated": 1, "errors": 0, "total": 1},
+        {"updated": 0, "errors": 1, "total": 1},
+    ],
+)
+@patch("tim.helpers.validate_bulk_cli_options")
+@patch("tim.opensearch.bulk_update")
+def test_bulk_update_fulltexts_logs_complete(
+    mock_bulk_update,
+    mock_validate_bulk_cli_options,
+    bulk_update_return,
+    caplog,
+    monkeypatch,
+    runner,
+):
+    monkeypatch.delenv("TIMDEX_OPENSEARCH_ENDPOINT", raising=False)
+    mock_bulk_update.return_value = bulk_update_return
+    mock_validate_bulk_cli_options.return_value = "libguides"
+
+    result = runner.invoke(
+        main,
+        [
+            "bulk-update-fulltexts",
+            "--source",
+            "libguides",
+            "--run-id",
+            "85cfe316-089c-4639-a5af-c861a7321493",
+            "tests/fixtures/dataset",
+        ],
+    )
+
+    assert result.exit_code == EXIT_CODES["success"]
+    assert (
+        f"Bulk update with fulltexts complete: {json.dumps(mock_bulk_update())}"
+        in caplog.text
+    )
+
+
+@patch("tim.helpers.validate_bulk_cli_options")
+@patch("tim.opensearch.bulk_update")
+def test_bulk_update_fulltexts_exit_bulk_operation_error(
+    mock_bulk_update, mock_validate_bulk_cli_options, caplog, monkeypatch, runner
+):
+    monkeypatch.delenv("TIMDEX_OPENSEARCH_ENDPOINT", raising=False)
+    mock_bulk_update.side_effect = BulkOperationError(
+        action="update", record="alma:0", index="index", error="exception"
+    )
+    mock_validate_bulk_cli_options.return_value = "libguides"
+
+    result = runner.invoke(
+        main,
+        [
+            "bulk-update-fulltexts",
+            "--source",
+            "libguides",
+            "--run-id",
+            "85cfe316-089c-4639-a5af-c861a7321493",
+            "tests/fixtures/dataset",
+        ],
+    )
+    assert result.exit_code == EXIT_CODES["error"]
+    assert "Bulk update with fulltexts failed" in caplog.text
+
+
+@patch("tim.helpers.validate_bulk_cli_options")
+@patch("tim.opensearch.bulk_update")
+def test_bulk_update_fulltexts_source_only_logs_complete(
+    mock_bulk_update,
+    mock_validate_bulk_cli_options,
+    caplog,
+    monkeypatch,
+    runner,
+):
+    monkeypatch.delenv("TIMDEX_OPENSEARCH_ENDPOINT", raising=False)
+    bulk_update_return = {"updated": 1, "errors": 0, "total": 1}
+    mock_bulk_update.return_value = bulk_update_return
+    mock_validate_bulk_cli_options.return_value = "libguides"
+
+    result = runner.invoke(
+        main,
+        [
+            "bulk-update-fulltexts",
+            "--source",
+            "libguides",
+            "tests/fixtures/dataset",
+        ],
+    )
+
+    assert result.exit_code == EXIT_CODES["success"]
+    assert (
+        f"Bulk update with fulltexts complete: {json.dumps(bulk_update_return)}"
+        in caplog.text
+    )
+
+
 @patch("tim.opensearch.create_index")
 @patch("tim.opensearch.promote_index")
 @patch("tim.opensearch.get_index_aliases")

--- a/tim/cli.py
+++ b/tim/cli.py
@@ -25,7 +25,12 @@ click.rich_click.COMMAND_GROUPS = {
         },
         {
             "name": "Bulk record processing commands",
-            "commands": ["bulk-update", "bulk-update-embeddings", "reindex-source"],
+            "commands": [
+                "bulk-update",
+                "bulk-update-embeddings",
+                "bulk-update-fulltexts",
+                "reindex-source",
+            ],
         },
     ]
 }
@@ -366,7 +371,7 @@ def bulk_update_embeddings(
 
     The method will read vector embeddings from a TIMDEXDataset
     located at dataset_path using the 'timdex-dataset-api' library. The dataset
-    is filtered by run date and run ID.
+    is filtered by run ID.
     """
     client = ctx.obj["CLIENT"]
     index = helpers.validate_bulk_cli_options(index, source, client)
@@ -411,6 +416,93 @@ def bulk_update_embeddings(
 
     except BulkOperationError as exception:
         logger.error(f"Bulk update with embeddings failed: {exception}")  # noqa: TRY400
+        ctx.exit(1)
+
+
+@main.command()
+@click.option(
+    "-i",
+    "--index",
+    help="Name of the index where the bulk update to add embeddings is performed.",
+)
+@click.option(
+    "-s",
+    "--source",
+    type=click.Choice(VALID_SOURCES),
+    help=(
+        "Source whose primary-aliased index will receive the bulk updated records with "
+        "embeddings.  If --run-id is not passed, all current embeddings for this source "
+        "will be used."
+    ),
+)
+@click.option(
+    "-rid",
+    "--run-id",
+    help="Limit to embeddings for a specific TIMDEX ETL run.",
+)
+@click.argument("dataset_path", type=click.Path())
+@click.pass_context
+def bulk_update_fulltexts(
+    ctx: click.Context,
+    index: str,
+    source: str,
+    run_id: str,
+    dataset_path: str,
+) -> None:
+    """Bulk update existing records with fulltexts for an index.
+
+    Must provide either the name of an existing index in the cluster or a valid source.
+    If source is provided, it will update existing records for the primary-aliased
+    index for the source. If the provided index doesn't exist in the cluster, the
+    method will log an error and abort.
+
+    The method will read fulltexts from a TIMDEXDataset located at dataset_path using
+    the 'timdex-dataset-api' library. The dataset is filtered by run ID.
+    """
+    client = ctx.obj["CLIENT"]
+    index = helpers.validate_bulk_cli_options(index, source, client)
+
+    logger.info(
+        f"Bulk updating records with fulltexts from dataset '{dataset_path}' "
+        f"into '{index}'"
+    )
+
+    td = TIMDEXDataset(location=dataset_path)
+
+    # read fulltexts for a specific run
+    if run_id:
+        read_kwargs = {
+            "table": "current_run_fulltexts",
+            "columns": [
+                "timdex_record_id",
+                "fulltext",
+            ],
+            "run_id": run_id,
+            "action": "index",
+        }
+
+    # default: read current fulltexts for a source
+    else:
+        read_kwargs = {
+            "table": "current_fulltexts",
+            "source": source,
+            "columns": [
+                "timdex_record_id",
+                "fulltext",
+            ],
+            "action": "index",
+        }
+
+    fulltexts = td.fulltexts.read_dicts_iter(**read_kwargs)
+
+    fulltexts_to_index = helpers.format_fulltexts(fulltexts)
+
+    try:
+        update_results = tim_os.bulk_update(client, index, fulltexts_to_index)
+        logger.info(f"Bulk update with fulltexts complete: {json.dumps(update_results)}")
+
+    except BulkOperationError as exception:
+        logger.error(f"Bulk update with fulltexts failed: {exception}")  # noqa: TRY400
         ctx.exit(1)
 
 

--- a/tim/helpers.py
+++ b/tim/helpers.py
@@ -35,6 +35,15 @@ def format_embeddings(embeddings: Iterator[dict]) -> Iterator[dict]:
         }
 
 
+def format_fulltexts(fulltexts: Iterator[dict]) -> Iterator[dict]:
+    """Format fulltexts for bulk update command."""
+    for fulltext in fulltexts:
+        yield {
+            "timdex_record_id": fulltext["timdex_record_id"],
+            "fulltext": fulltext["fulltext"].decode(),
+        }
+
+
 def generate_index_name(source: str) -> str:
     """Generate a new index name from a source short name.
 

--- a/uv.lock
+++ b/uv.lock
@@ -1438,7 +1438,7 @@ wheels = [
 [[package]]
 name = "timdex-dataset-api"
 version = "5.1.0"
-source = { git = "https://github.com/MITLibraries/timdex-dataset-api.git#450af3c615389f1847883fa19879fa94a08c59af" }
+source = { git = "https://github.com/MITLibraries/timdex-dataset-api#450af3c615389f1847883fa19879fa94a08c59af" }
 dependencies = [
     { name = "attrs" },
     { name = "boto3" },
@@ -1487,7 +1487,7 @@ requires-dist = [
     { name = "rich-click" },
     { name = "sentry-sdk" },
     { name = "smart-open", extras = ["s3"] },
-    { name = "timdex-dataset-api", git = "https://github.com/MITLibraries/timdex-dataset-api.git" },
+    { name = "timdex-dataset-api", git = "https://github.com/MITLibraries/timdex-dataset-api" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
_NOTE: this PR builds on https://github.com/MITLibraries/timdex-index-manager/pull/387.  Will change base on merge of that PR._

### Purpose and background context

This PR adds a new CLI command `bulk-update-fulltexts` to TIM.  This is a near clone of pre-existing CLI command `bulk-update-embeddings`.

As noted in the ticket and commit, it was decided to accept some code duplication in the name of simplicity at the moment.  There may be a way to combine these, something like `bulk-update` with a TIMDEX "data type" flag to set, but it would require some helper methods and branching as the logic _does_ differ slightly.  Given there is some StepFunction refactoring anticipated in coming months, felt more aligned with that work.

With this CLI command added, we'll have the ability to add a new block in the TIMDEX StepFunction to update documents with harvested fulltext (first use case, DSpace theses).  

### How can a reviewer manually see the effects of these changes?

The following will run the `bulk-update-fulltexts` command for a small run of `researchdatabases` in Dev.  Note that the fulltext records are just simulated records for this source, but do exercise the CLI command correctly.

1- Set Dev1 `TimdexManager` credentials

2- Set env vars:
```
WORKSPACE=dev
WARNING_ONLY_LOGGERS=boto3,botocore,opensearch,urllib3
TDA_LOG_LEVEL=DEBUG
AUTH_SERVICE_TYPE=es
TIMDEX_OPENSEARCH_ENDPOINT=search-timdex-dev-fgby3dckzlfmni2len2wbdf444.us-east-1.es.amazonaws.com
TIMDEX_DATASET_LOCATION=s3://timdex-extract-dev-222053980223/dataset
```

3- Run CLI command:
```shell
uv run --env-file .env tim --verbose \
bulk-update-fulltexts \
-s researchdatabases \
--run-id=18cbec87-ce25-4355-a526-caaa3eb1ac1e \
s3://timdex-extract-dev-222053980223/dataset
```

Should see output:
```
Bulk update with fulltexts complete: {"updated": 901, "skipped": 0, "errors": 0, "total": 901}
```

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
YES: unlocks a StepFunction update to add a new fulltext harvesting + indexing section

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/USE-559

### Code review
* Code review best practices are documented [here](https://mitlibraries.github.io/guides/collaboration/code_review.html) and you are encouraged to have a constructive dialogue with your reviewers about their preferences and expectations.