### PR TITLE
Retry failed indexes and updates caused by OCU scaling

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,13 @@ def timdex_dataset() -> TIMDEXDataset:
 
 
 @pytest.fixture
+def one_valid_index_libguides_records(timdex_dataset):
+    return timdex_dataset.records.read_transformed_records_iter(
+        run_id="85cfe316-089c-4639-a5af-c861a7321493", limit=1
+    )
+
+
+@pytest.fixture
 def five_valid_index_libguides_records(timdex_dataset):
     return timdex_dataset.records.read_transformed_records_iter(
         run_id="85cfe316-089c-4639-a5af-c861a7321493"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,9 +3,10 @@ import re
 from unittest.mock import patch
 
 import pytest
+from click.exceptions import BadParameter, UsageError
 from freezegun import freeze_time
 
-from tim.cli import main
+from tim.cli import main, validate_bulk_cli_options
 from tim.errors import BulkIndexingError, BulkOperationError
 
 from .conftest import EXIT_CODES, my_vcr
@@ -187,7 +188,7 @@ def test_promote_index(caplog, runner):
 # Test bulk record processing commands
 
 
-@patch("tim.helpers.validate_bulk_cli_options")
+@patch("tim.cli.validate_bulk_cli_options")
 @patch("tim.opensearch.bulk_delete")
 @patch("tim.opensearch.bulk_index")
 def test_bulk_update_with_source_success(
@@ -229,7 +230,7 @@ def test_bulk_update_with_source_success(
     )
 
 
-@patch("tim.helpers.validate_bulk_cli_options")
+@patch("tim.cli.validate_bulk_cli_options")
 @patch("tim.opensearch.bulk_delete")
 @patch("tim.opensearch.bulk_index")
 def test_bulk_update_with_source_raise_bulk_indexing_error(
@@ -282,7 +283,7 @@ def test_bulk_update_with_source_raise_bulk_indexing_error(
         {"updated": 0, "errors": 1, "total": 1},
     ],
 )
-@patch("tim.helpers.validate_bulk_cli_options")
+@patch("tim.cli.validate_bulk_cli_options")
 @patch("tim.opensearch.bulk_update")
 def test_bulk_update_embeddings_logs_complete(
     mock_bulk_update,
@@ -315,7 +316,7 @@ def test_bulk_update_embeddings_logs_complete(
     )
 
 
-@patch("tim.helpers.validate_bulk_cli_options")
+@patch("tim.cli.validate_bulk_cli_options")
 @patch("tim.opensearch.bulk_update")
 def test_bulk_update_embeddings_exit_bulk_operation_error(
     mock_bulk_update, mock_validate_bulk_cli_options, caplog, monkeypatch, runner
@@ -341,7 +342,7 @@ def test_bulk_update_embeddings_exit_bulk_operation_error(
     assert "Bulk update with embeddings failed" in caplog.text
 
 
-@patch("tim.helpers.validate_bulk_cli_options")
+@patch("tim.cli.validate_bulk_cli_options")
 @patch("tim.opensearch.bulk_update")
 def test_bulk_update_embeddings_source_only_logs_complete(
     mock_bulk_update,
@@ -379,7 +380,7 @@ def test_bulk_update_embeddings_source_only_logs_complete(
         {"updated": 0, "errors": 1, "total": 1},
     ],
 )
-@patch("tim.helpers.validate_bulk_cli_options")
+@patch("tim.cli.validate_bulk_cli_options")
 @patch("tim.opensearch.bulk_update")
 def test_bulk_update_fulltexts_logs_complete(
     mock_bulk_update,
@@ -412,7 +413,7 @@ def test_bulk_update_fulltexts_logs_complete(
     )
 
 
-@patch("tim.helpers.validate_bulk_cli_options")
+@patch("tim.cli.validate_bulk_cli_options")
 @patch("tim.opensearch.bulk_update")
 def test_bulk_update_fulltexts_exit_bulk_operation_error(
     mock_bulk_update, mock_validate_bulk_cli_options, caplog, monkeypatch, runner
@@ -438,7 +439,7 @@ def test_bulk_update_fulltexts_exit_bulk_operation_error(
     assert "Bulk update with fulltexts failed" in caplog.text
 
 
-@patch("tim.helpers.validate_bulk_cli_options")
+@patch("tim.cli.validate_bulk_cli_options")
 @patch("tim.opensearch.bulk_update")
 def test_bulk_update_fulltexts_source_only_logs_complete(
     mock_bulk_update,
@@ -551,3 +552,40 @@ def test_reindex_source_skip_embeddings(
     assert result.exit_code == EXIT_CODES["success"]
     assert "Skipping embeddings update." in caplog.text
     mock_bulk_update.assert_not_called()
+
+
+def test_validate_bulk_cli_options_neither_index_nor_source_passed(
+    test_opensearch_client,
+):
+    with pytest.raises(
+        UsageError, match=r"Must provide either an existing index name or a valid source."
+    ):
+        validate_bulk_cli_options(test_opensearch_client, None, None)
+
+
+def test_validate_bulk_cli_options_index_and_source_passed(test_opensearch_client):
+    with pytest.raises(
+        UsageError,
+        match=r"Only one of --index and --source options is allowed, not both.",
+    ):
+        validate_bulk_cli_options(test_opensearch_client, "index-name", "source-name")
+
+
+@my_vcr.use_cassette("helpers/bulk_cli_nonexistent_index.yaml")
+def test_validate_bulk_cli_options_nonexistent_index_passed(test_opensearch_client):
+    with pytest.raises(
+        BadParameter, match=r"Index 'wrong' does not exist in the cluster."
+    ):
+        validate_bulk_cli_options(test_opensearch_client, "wrong", None)
+
+
+@my_vcr.use_cassette("helpers/bulk_cli_no_primary_index_for_source.yaml")
+def test_validate_bulk_cli_options_no_primary_index_for_source(test_opensearch_client):
+    with pytest.raises(
+        BadParameter,
+        match=(
+            r"No index name was passed and there is no "
+            r"primary-aliased index for source 'dspace'."
+        ),
+    ):
+        validate_bulk_cli_options(test_opensearch_client, None, "dspace")

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,10 +1,76 @@
+from unittest.mock import Mock, patch
+
 import pytest
-from click.exceptions import BadParameter, UsageError
+from click.exceptions import BadParameter
 from freezegun import freeze_time
+from opensearchpy.exceptions import TransportError
 
 from tim import helpers
+from tim.errors import SingleOperationError
 
-from .conftest import my_vcr
+
+@freeze_time("2026-07-09 10:00:00", auto_tick_seconds=10)
+@patch("tim.helpers.time.sleep")
+def test_retry_decorator_with_sleep_success(mock_sleep):
+    """Retry resulting in retryable error returns success within allowed time."""
+    # init TransportError with 507 status
+    retryable_error = TransportError(507, "Insufficient Storage")
+
+    # mock method that yields TransportError to force retry
+    # then yields success after retry
+    hello_world = Mock()
+    hello_world.__name__ = "hello_world"
+    hello_world.side_effect = [retryable_error, "Hello"]
+
+    wrapped_hello_world = helpers.retry()(hello_world)
+
+    assert wrapped_hello_world() == "Hello"
+    assert hello_world.call_count == 2  # noqa: PLR2004
+
+
+@patch("tim.helpers.time.sleep")
+def test_retry_decorator_with_sleep_raises_timeout_error(mock_sleep):
+    """Retry resulting in retryable error raises error if timeout reached."""
+    # init TransportError with 507 status
+    retryable_error = TransportError(507, "Insufficient Storage")
+
+    # mock method that yields TransportError to force retry
+    # then yields success after retry
+    hello_world = Mock()
+    hello_world.__name__ = "hello_world"
+    hello_world.side_effect = retryable_error
+
+    wrapped_hello_world = helpers.retry(max_attempts=2)(hello_world)
+
+    with pytest.raises(TimeoutError):
+        wrapped_hello_world()
+    assert hello_world.call_count == 2  # noqa: PLR2004
+
+
+@patch("tim.helpers.time.sleep")
+def test_retry_decorator_without_sleep(mock_sleep):
+    """Retry resulting in success returns immediately."""
+
+    @helpers.retry()
+    def hello_world():
+        return "Hello"
+
+    result = hello_world()
+
+    assert result == "Hello"
+    assert mock_sleep.call_count == 0
+
+
+@patch("tim.helpers.time.sleep")
+def test_retry_decorator_raises_single_operation_error(mock_sleep):
+    """Retry resulting in unexpected error raises error."""
+
+    @helpers.retry()
+    def hello_world():
+        raise Exception("Unexpected error")  # noqa: TRY002
+
+    with pytest.raises(SingleOperationError):
+        hello_world()
 
 
 def test_confirm_action_yes(monkeypatch):
@@ -75,45 +141,6 @@ def test_get_source_from_index():
 
 def test_get_source_from_index_without_dash():
     assert helpers.get_source_from_index("testsource") == "testsource"
-
-
-def test_validate_bulk_cli_options_neither_index_nor_source_passed(
-    test_opensearch_client,
-):
-    with pytest.raises(
-        UsageError, match=r"Must provide either an existing index name or a valid source."
-    ):
-        helpers.validate_bulk_cli_options(None, None, test_opensearch_client)
-
-
-def test_validate_bulk_cli_options_index_and_source_passed(test_opensearch_client):
-    with pytest.raises(
-        UsageError,
-        match=r"Only one of --index and --source options is allowed, not both.",
-    ):
-        helpers.validate_bulk_cli_options(
-            "index-name", "source-name", test_opensearch_client
-        )
-
-
-@my_vcr.use_cassette("helpers/bulk_cli_nonexistent_index.yaml")
-def test_validate_bulk_cli_options_nonexistent_index_passed(test_opensearch_client):
-    with pytest.raises(
-        BadParameter, match=r"Index 'wrong' does not exist in the cluster."
-    ):
-        helpers.validate_bulk_cli_options("wrong", None, test_opensearch_client)
-
-
-@my_vcr.use_cassette("helpers/bulk_cli_no_primary_index_for_source.yaml")
-def test_validate_bulk_cli_options_no_primary_index_for_source(test_opensearch_client):
-    with pytest.raises(
-        BadParameter,
-        match=(
-            r"No index name was passed and there is no "
-            r"primary-aliased index for source 'dspace'."
-        ),
-    ):
-        helpers.validate_bulk_cli_options(None, "dspace", test_opensearch_client)
 
 
 def test_validate_index_name_no_value():

--- a/tests/test_opensearch.py
+++ b/tests/test_opensearch.py
@@ -15,6 +15,38 @@ from tim.errors import (
 
 from .conftest import my_vcr
 
+
+# Fixture
+@pytest.fixture
+def mock_streaming_bulk(request):
+    action_type = request.param
+
+    def _streaming_bulk(client, actions, *args, **kwargs):
+        # exhaust generator => fills actions_cache via generate_bulk_actions()
+        actions_list = list(actions)
+
+        # return an iterable of (ok, item) like streaming_bulk(..., raise_on_error=False)
+        return iter(
+            (
+                False,
+                {
+                    action_type: {
+                        "_index": "test-index",
+                        "_id": "libguides:guides-175846",
+                        "status": 507,
+                        "error": {
+                            "type": "internal_server_exception",
+                            "reason": "Internal error occurred while processing request",
+                        },
+                    }
+                },
+            )
+            for _ in actions_list
+        )
+
+    return _streaming_bulk
+
+
 # Cluster functions
 
 
@@ -506,6 +538,32 @@ def test_bulk_index_logs_mapper_parsing_errors(
     assert "Error indexing record 'libguides:guides-175846'" in caplog.text
 
 
+@pytest.mark.parametrize("mock_streaming_bulk", ["index"], indirect=True)
+@mock.patch("tim.opensearch.execute_single_record_action")
+@mock.patch("tim.helpers.retry")
+def test_bulk_index_retries_transport_error_507(
+    mock_retry,
+    mock_execute_single_record_action,
+    mock_streaming_bulk,
+    test_opensearch_client,
+    one_valid_index_libguides_records,
+):
+    # mock successful client.index response
+    mock_execute_single_record_action.return_value = {
+        "_index": "test-index",
+        "_id": "libguides:guides-175846",
+        "_version": 1,
+        "result": "created",
+    }
+    with mock.patch("tim.opensearch.streaming_bulk", side_effect=mock_streaming_bulk):
+        result = tim_os.bulk_index(
+            test_opensearch_client, "test-index", one_valid_index_libguides_records
+        )
+
+    assert result["created"] == 1
+    assert mock_execute_single_record_action.call_count == 1
+
+
 @my_vcr.use_cassette("opensearch/bulk_delete_records.yaml")
 def test_bulk_delete_deletes_records(
     caplog, monkeypatch, test_opensearch_client, one_valid_delete_libguides_records
@@ -577,3 +635,29 @@ def test_bulk_update_records_error_record_not_found(
         """Details: {"type": "document_missing_exception", """
         """"reason": "[i-am-not-found]: document missing","""
     ) in caplog.text
+
+
+@pytest.mark.parametrize("mock_streaming_bulk", ["update"], indirect=True)
+@mock.patch("tim.opensearch.execute_single_record_action")
+@mock.patch("tim.helpers.retry")
+def test_bulk_update_retries_transport_error_507(
+    mock_retry,
+    mock_execute_single_record_action,
+    mock_streaming_bulk,
+    test_opensearch_client,
+    one_valid_index_libguides_records,
+):
+
+    mock_execute_single_record_action.return_value = {
+        "_index": "test-index",
+        "_id": "libguides:guides-175846",
+        "_version": 1,
+        "result": "updated",
+    }
+    with mock.patch("tim.opensearch.streaming_bulk", side_effect=mock_streaming_bulk):
+        result = tim_os.bulk_update(
+            test_opensearch_client, "test-index", one_valid_index_libguides_records
+        )
+
+    assert result["updated"] == 1
+    assert mock_execute_single_record_action.call_count == 1

--- a/tim/cli.py
+++ b/tim/cli.py
@@ -9,7 +9,7 @@ from timdex_dataset_api import TIMDEXDataset
 from tim import errors, helpers
 from tim import opensearch as tim_os
 from tim.config import PRIMARY_ALIAS, VALID_SOURCES, configure_logger, configure_sentry
-from tim.errors import BulkIndexingError, BulkOperationError
+from tim.errors import BulkIndexingError, BulkOperationError, SingleOperationError
 
 logger = logging.getLogger(__name__)
 
@@ -296,7 +296,7 @@ def bulk_update(
     Logs an error and aborts if the provided index doesn't exist in the cluster.
     """
     client = ctx.obj["CLIENT"]
-    index = helpers.validate_bulk_cli_options(index, source, client)
+    index = validate_bulk_cli_options(client, index, source)
 
     logger.info(f"Bulk updating records from dataset '{dataset_path}' into '{index}'")
 
@@ -313,7 +313,7 @@ def bulk_update(
     )
     try:
         index_results.update(tim_os.bulk_index(client, index, records_to_index))
-    except BulkIndexingError as exception:
+    except (BulkIndexingError, SingleOperationError, TimeoutError) as exception:
         logger.error(f"Bulk indexing failed: {exception}")  # noqa: TRY400
 
     # bulk delete records
@@ -374,7 +374,7 @@ def bulk_update_embeddings(
     is filtered by run ID.
     """
     client = ctx.obj["CLIENT"]
-    index = helpers.validate_bulk_cli_options(index, source, client)
+    index = validate_bulk_cli_options(client, index, source)
 
     logger.info(
         f"Bulk updating records with embeddings from dataset '{dataset_path}' "
@@ -413,8 +413,7 @@ def bulk_update_embeddings(
     try:
         update_results = tim_os.bulk_update(client, index, embeddings_to_index)
         logger.info(f"Bulk update with embeddings complete: {json.dumps(update_results)}")
-
-    except BulkOperationError as exception:
+    except (BulkOperationError, SingleOperationError, TimeoutError) as exception:
         logger.error(f"Bulk update with embeddings failed: {exception}")  # noqa: TRY400
         ctx.exit(1)
 
@@ -460,7 +459,7 @@ def bulk_update_fulltexts(
     the 'timdex-dataset-api' library. The dataset is filtered by run ID.
     """
     client = ctx.obj["CLIENT"]
-    index = helpers.validate_bulk_cli_options(index, source, client)
+    index = validate_bulk_cli_options(client, index, source)
 
     logger.info(
         f"Bulk updating records with fulltexts from dataset '{dataset_path}' "
@@ -500,8 +499,7 @@ def bulk_update_fulltexts(
     try:
         update_results = tim_os.bulk_update(client, index, fulltexts_to_index)
         logger.info(f"Bulk update with fulltexts complete: {json.dumps(update_results)}")
-
-    except BulkOperationError as exception:
+    except (BulkOperationError, SingleOperationError, TimeoutError) as exception:
         logger.error(f"Bulk update with fulltexts failed: {exception}")  # noqa: TRY400
         ctx.exit(1)
 
@@ -582,7 +580,7 @@ def reindex_source(
     )
     try:
         index_results.update(tim_os.bulk_index(client, index, records_to_index))
-    except BulkIndexingError as exception:
+    except (BulkIndexingError, SingleOperationError, TimeoutError) as exception:
         logger.error(f"Bulk indexing failed: {exception}")  # noqa: TRY400
 
     # bulk index embeddings
@@ -604,10 +602,36 @@ def reindex_source(
         embeddings_to_index = helpers.format_embeddings(embeddings)
         try:
             update_results.update(tim_os.bulk_update(client, index, embeddings_to_index))
-        except BulkOperationError as exception:
+        except (BulkOperationError, SingleOperationError, TimeoutError) as exception:
             logger.error(  # noqa: TRY400
                 f"Bulk update with embeddings failed: {exception}"
             )
 
     summary_results = {"index": index_results, "update": update_results}
     logger.info(f"Reindex source complete: {json.dumps(summary_results)}")
+
+
+def validate_bulk_cli_options(
+    client: tim_os.OpenSearch,
+    index: str | None,
+    source: str,
+) -> str:
+    options = [index, source]
+    if all(options):
+        message = "Only one of --index and --source options is allowed, not both."
+        raise click.UsageError(message)
+    if not any(options):
+        message = "Must provide either an existing index name or a valid source."
+        raise click.UsageError(message)
+    if index and not client.indices.exists(index):
+        message = f"Index '{index}' does not exist in the cluster."
+        raise click.BadParameter(message)
+    if source:
+        index = tim_os.get_primary_index_for_source(client, source)
+    if not index:
+        message = (
+            "No index name was passed and there is no primary-aliased index for "
+            f"source '{source}'."
+        )
+        raise click.BadParameter(message)
+    return index

--- a/tim/errors.py
+++ b/tim/errors.py
@@ -35,6 +35,10 @@ class BulkOperationError(Exception):
         super().__init__(self.message)
 
 
+class SingleOperationError(Exception):
+    """Exception raised when an unexpected error occurs during a single operation."""
+
+
 class IndexExistsError(Exception):
     """Exception raised when attempting to create an index that is already present."""
 

--- a/tim/helpers.py
+++ b/tim/helpers.py
@@ -1,11 +1,67 @@
+import functools
 import json
-from collections.abc import Generator, Iterator
+import logging
+import time
+from collections import defaultdict
+from collections.abc import Callable, Generator, Iterator
 from datetime import UTC, datetime
 
 import click
+from opensearchpy.exceptions import TransportError
 
-from tim import opensearch as tim_os
 from tim.config import VALID_BULK_OPERATIONS, VALID_SOURCES
+from tim.errors import SingleOperationError
+
+logger = logging.getLogger(__name__)
+TRANSPORT_ERROR_507 = 507
+
+
+def retry(
+    delay: float = 5,
+    max_attempts: int = 8,
+) -> Callable:
+    """Retry the decorated function until success or max attempts reached.
+
+    Args:
+        delay: Time to wait, in seconds, between retry attempts. This value is
+        multiplied by the attempt number, resulting in a progressive backoff.
+        max_attempts: Number of allowed retries.
+    """
+
+    def retry_decorator(func: Callable) -> Callable:
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs) -> Callable:  # type: ignore[no-untyped-def] # noqa: ANN002, ANN003
+            attempt = 0
+
+            while attempt < max_attempts:
+                attempt += 1
+                logger.info(f"Calling {func.__name__}, attempt {attempt}")
+
+                try:
+                    return func(*args, **kwargs)
+                except Exception as exception:
+                    if (
+                        isinstance(exception, TransportError)
+                        and exception.status_code == TRANSPORT_ERROR_507
+                    ):
+                        logger.warning(
+                            f"{func.__name__} raised retryable exception, attempt {attempt}: "  # noqa: E501
+                            f"{exception}"
+                        )
+                    else:
+                        logger.exception(
+                            f"{func.__name__} raised unexpected exception, attempt {attempt}"  # noqa: E501
+                        )
+                        raise SingleOperationError from exception
+
+                logger.debug(f"Sleeping {delay} seconds before retrying {func.__name__}")
+                time.sleep(delay * attempt)
+
+            raise TimeoutError(f"Timed out after {attempt} attempts")
+
+        return wrapper
+
+    return retry_decorator
 
 
 def confirm_action(input_prompt: str) -> bool:
@@ -55,9 +111,7 @@ def generate_index_name(source: str) -> str:
 
 
 def generate_bulk_actions(
-    index: str,
-    records: Iterator[dict],
-    action: str,
+    index: str, records: Iterator[dict], action: str, cache: defaultdict | None = None
 ) -> Generator[dict]:
     """Iterate through records, create and yield an OpenSearch bulk action for each.
 
@@ -83,6 +137,9 @@ def generate_bulk_actions(
             case _ if action != "delete":
                 doc["_source"] = record
 
+        if cache is not None:
+            cache[record["timdex_record_id"]].append(doc)
+
         yield doc
 
 
@@ -90,28 +147,13 @@ def get_source_from_index(index_name: str) -> str:
     return index_name.split("-", maxsplit=1)[0]
 
 
-def validate_bulk_cli_options(
-    index: str | None, source: str, client: tim_os.OpenSearch
-) -> str:
-    options = [index, source]
-    if all(options):
-        message = "Only one of --index and --source options is allowed, not both."
-        raise click.UsageError(message)
-    if not any(options):
-        message = "Must provide either an existing index name or a valid source."
-        raise click.UsageError(message)
-    if index and not client.indices.exists(index):
-        message = f"Index '{index}' does not exist in the cluster."
-        raise click.BadParameter(message)
-    if source:
-        index = tim_os.get_primary_index_for_source(client, source)
-    if not index:
-        message = (
-            "No index name was passed and there is no primary-aliased index for "
-            f"source '{source}'."
-        )
-        raise click.BadParameter(message)
-    return index
+def pop_cache_entry(cache: defaultdict, record_id: str) -> None:
+    """Remove the oldest action for a record from the cache."""
+    actions_deque = cache.get(record_id)
+    if actions_deque:
+        actions_deque.popleft()
+        if not actions_deque:
+            del cache[record_id]
 
 
 def validate_index_name(

--- a/tim/opensearch.py
+++ b/tim/opensearch.py
@@ -1,7 +1,9 @@
 import json
 import logging
 import os
+from collections import defaultdict, deque
 from collections.abc import Iterator
+from typing import Any
 
 import boto3
 from opensearchpy import AWSV4SignerAuth, OpenSearch, RequestsHttpConnection
@@ -25,6 +27,7 @@ from tim.errors import (
 logger = logging.getLogger(__name__)
 
 REQUEST_CONFIG = configure_opensearch_bulk_settings()
+TRANSPORT_ERROR_507 = 507
 
 # Cluster functions
 
@@ -388,7 +391,8 @@ def bulk_index(client: OpenSearch, index: str, records: Iterator[dict]) -> dict[
     processed.
     """
     result = {"created": 0, "updated": 0, "errors": 0, "total": 0}
-    actions = helpers.generate_bulk_actions(index, records, "index")
+    actions_cache: defaultdict = defaultdict(deque)
+    actions = helpers.generate_bulk_actions(index, records, "index", actions_cache)
     responses = streaming_bulk(
         client,
         actions,
@@ -398,18 +402,28 @@ def bulk_index(client: OpenSearch, index: str, records: Iterator[dict]) -> dict[
         raise_on_error=False,
     )
     for response in responses:
+        record_id = response[1]["index"]["_id"]
         if response[0] is False:
+            status = response[1]["index"]["status"]
             error = response[1]["index"]["error"]
-            record = response[1]["index"]["_id"]
             if error["type"] == "mapper_parsing_exception":
                 logger.error(
                     "Error indexing record '%s'. Details: %s",
-                    record,
+                    record_id,
                     json.dumps(error),
                 )
                 result["errors"] += 1
+            elif status == TRANSPORT_ERROR_507:
+                retry_response = execute_single_record_action(
+                    client,
+                    index,
+                    record_id=record_id,
+                    body=actions_cache[record_id][0]["_source"],
+                    operation="index",
+                )
+                result[retry_response["result"]] += 1
             else:
-                raise BulkIndexingError(record, index, json.dumps(error))
+                raise BulkIndexingError(record_id, index, json.dumps(error))
         elif response[1]["index"].get("result") == "created":
             result["created"] += 1
         elif response[1]["index"].get("result") == "updated":
@@ -421,8 +435,13 @@ def bulk_index(client: OpenSearch, index: str, records: Iterator[dict]) -> dict[
             )
             result["errors"] += 1
         result["total"] += 1
+
+        # remove record action from cache after processing
+        helpers.pop_cache_entry(actions_cache, record_id)
+
         if result["total"] % int(os.getenv("STATUS_UPDATE_INTERVAL", "1000")) == 0:
             logger.info("Status update: %s records indexed so far!", result["total"])
+
     return result
 
 
@@ -440,7 +459,8 @@ def bulk_update(
     processed.
     """
     result = {"updated": 0, "skipped": 0, "errors": 0, "total": 0}
-    actions = helpers.generate_bulk_actions(index, records, "update")
+    actions_cache: defaultdict = defaultdict(deque)
+    actions = helpers.generate_bulk_actions(index, records, "update", actions_cache)
     responses = streaming_bulk(
         client,
         actions,
@@ -450,24 +470,37 @@ def bulk_update(
         raise_on_error=False,
     )
     for response in responses:
+        record_id = response[1]["update"]["_id"]
         if response[0] is False:
+            status = response[1]["update"]["status"]
             error = response[1]["update"]["error"]
-            record = response[1]["update"]["_id"]
             if error["type"] in [
                 "mapper_parsing_exception",
                 "document_missing_exception",
             ]:
                 logger.error(
                     "Error updating record '%s'. Details: %s",
-                    record,
+                    record_id,
                     json.dumps(error),
                 )
                 result["errors"] += 1
+            elif status == TRANSPORT_ERROR_507:
+                retry_response = execute_single_record_action(
+                    client,
+                    index,
+                    record_id=record_id,
+                    body=actions_cache[record_id][0]["doc"],
+                    operation="update",
+                )
+                if retry_response["result"] == "updated":
+                    result["updated"] += 1
+                elif retry_response["result"] == "noop":
+                    result["skipped"] += 1
             else:
                 message = "update"
                 raise BulkOperationError(
                     message,
-                    record,
+                    record_id,
                     index,
                     json.dumps(error),
                 )
@@ -482,6 +515,36 @@ def bulk_update(
             )
             result["errors"] += 1
         result["total"] += 1
+
+        # remove record action from cache after processing
+        helpers.pop_cache_entry(actions_cache, record_id)
+
         if result["total"] % int(os.getenv("STATUS_UPDATE_INTERVAL", "1000")) == 0:
             logger.info("Status update: %s records updated so far!", result["total"])
+
     return result
+
+
+@helpers.retry()
+def execute_single_record_action(
+    client: OpenSearch, index: str, record_id: str, body: dict, operation: str
+) -> dict[str, Any]:
+    """Execute an OpenSearch action for a single record.
+
+    Supports index, update, and delete actions for one record. The action
+    is dispatched to the corresponding OpenSearch client method based on
+    `operation`.
+    """
+    logger.info(f"Retrying '{operation}' operation for {record_id}")
+    method = getattr(client, operation)
+    if operation == "index":
+        method_args = {"index": index, "id": record_id, "body": body}
+    elif operation == "update":
+        method_args = {"index": index, "id": record_id, "body": {"doc": body}}
+    elif operation == "delete":
+        method_args = {
+            "index": index,
+            "id": record_id,
+        }
+
+    return method(**method_args)


### PR DESCRIPTION
### Purpose and background context
Amazon OpenSearch Serverless (AOSS) automatically scales up resources to handle heavy data ingestion spikes. When TIM runs bulk operations for multiple sources (e.g., reindexing all TIMDEX sources), AOSS may requiring scaling up OCUs. Requests sent to the OpenSearch API may occasionally result in HTTP 507 Insufficient Storage (`TransportError`), which can terminate a bulk operation abruptly and result in incomplete jobs.

The changes introduce the use of a cache to keep track of bulk actions and a `retry` decorator that retries any failing 'index' or 'update' operation stored in the cache caused by the HTTP 507 error. 

The sections below discuss three important topics:
* What is the current `bulk_index/update` workflow with retries
* How [`execute_single_record_action`](https://github.com/MITLibraries/timdex-index-manager/blob/TIMX-639-retry-failures-from-ocu-scaling/tim/opensearch.py#L520-L539) performs retries
* Why we aren't retrying `bulk_delete` at this time

---

#### 🤔 What is the current `bulk_index/update` workflow with retries?
* Please use `tim.opensearch.bulk_index` for reference as you read on!
* An `actions_cache` is created at the beginning. The cache comprises of a `defaultdict` where values are a [`dequeue` object](https://docs.python.org/3/library/collections.html#collections.deque). The contents of the cache make look like this:
    ```python
    {"<timdex_record_id>":  deque(["<first action encountered>", "<second action encountered>"}
    ```
   * A `deque` object is used because a TIMDEX run/harvest _can include multiple records_ for a single `timdex_record_id`. A `dequeue` is more performant when "popping" or removing older elements (FIFO).
* [`tim.helpers.generate_bulk_actions`](https://github.com/MITLibraries/timdex-index-manager/blob/TIMX-639-retry-failures-from-ocu-scaling/tim/helpers.py#L121-L151) can now accept the `actions_cache` via the new optional `cache` parameter. Remember, this method is a `generator`.
* The actions generator is passed into `streaming_bulk`.
*  As `streaming_bulk` does its thing (lol), it accesses elements from the `actions` generator, [the action recorded in the cache](https://github.com/MITLibraries/timdex-index-manager/blob/TIMX-639-retry-failures-from-ocu-scaling/tim/helpers.py#L148-L149) and performs the specified action. Remember, this is done in chunks! We then iterate over each response:
   * When `streaming_bulk(raise_on_error=False...)` is used, it returns a tuple `(ok, [item](https://docs.opensearch.org/latest/api-reference/document-apis/bulk/#the-items-array))`, where `ok` is a boolean indicating whether the response was a success.
      * When `response[0] is False`, this means the bulk operation failed. 
      * [TIM will retrieve the `timdex_record_id` and the `status` of the response](https://github.com/MITLibraries/timdex-index-manager/blob/TIMX-639-retry-failures-from-ocu-scaling/tim/opensearch.py#L405-L407) 
      * If the `status = 507`, it will run the [`retry`-decorated `execute_single_record_action()` method](https://github.com/MITLibraries/timdex-index-manager/blob/TIMX-639-retry-failures-from-ocu-scaling/tim/opensearch.py#L520-L539), passing the cached action associated with the `timdex_record_id`.
      * Read the next section to find out **How `execute_single_record_action` performs retries**.
* Assuming the bulk operation was processed successfully (with or without the retry), the oldest action for a given `timdex_record_id` is "popped"/removed from the cache
   *  NOTE: There will typically only be one action for each TIMDEX record at a time **_because of this step_**!

#### 🤔 How [`execute_single_record_action`](https://github.com/MITLibraries/timdex-index-manager/blob/TIMX-639-retry-failures-from-ocu-scaling/tim/opensearch.py#L520-L539) performs retries
* This method relies on the item-level `index|update` methods on `opensearchpy.client.OpenSearch`.
* Unlike `streaming_bulk(raise_error=False...)`, when `client.index|update` methods result in error, an error is raised.
* The [`tim.helpers.retry` decorator](https://github.com/MITLibraries/timdex-index-manager/blob/TIMX-639-retry-failures-from-ocu-scaling/tim/helpers.py#L19-L72) wraps the method and works as follows: 
   * Retrieve the `start_time` and track number of `attempt`
   * The method is nested in a `while` loop and will exit under the following conditions:
      * [The `client.index|update` method results in success (no error raised)](https://github.com/MITLibraries/timdex-index-manager/blob/TIMX-639-retry-failures-from-ocu-scaling/tim/helpers.py#L45) -> _**Return output from decorated method--again, this will take the form of [an item array](https://docs.opensearch.org/latest/api-reference/document-apis/bulk/#the-items-array) for the single record**_ 
      * [The `client.index|update` method results in an unexpected, non-retryable error](https://github.com/MITLibraries/timdex-index-manager/blob/TIMX-639-retry-failures-from-ocu-scaling/tim/helpers.py#L55-L59) -> _**Raises `SingleOperationError` from the unexpected error**_
      * [The `client.index|update` method results in 507, retryable error but timeout (defaults to 120 seconds) is reached](https://github.com/MITLibraries/timdex-index-manager/blob/TIMX-639-retry-failures-from-ocu-scaling/tim/helpers.py#L61-L65) -> _**Raises `TimeOutError`**_
      * Otherwise, the method will execute a `time.sleep(delay)` (defaults to 5 seconds).

#### 🤔 Why we aren't retrying `bulk_delete` at this time?
* First, remember that [`tim_os.bulk_delete` is called as part of the TIM `bulk-update` CLI command](https://github.com/MITLibraries/timdex-index-manager/blob/main/tim/cli.py#L326)
* Looking at [`tim.opensearch` (at the most recent commit before this PR)](https://github.com/MITLibraries/timdex-index-manager/blob/f240a3523e8ebad8e29a546aa62a3e34289b6a27/tim/opensearch.py):
   * The control flow for [`bulk_delete`](https://github.com/MITLibraries/timdex-index-manager/blob/f240a3523e8ebad8e29a546aa62a3e34289b6a27/tim/opensearch.py#L349-L369) is different from  the control flow shared by [`bulk_index`](https://github.com/MITLibraries/timdex-index-manager/blob/f240a3523e8ebad8e29a546aa62a3e34289b6a27/tim/opensearch.py#L400-L425) and [`bulk_update`](https://github.com/MITLibraries/timdex-index-manager/blob/f240a3523e8ebad8e29a546aa62a3e34289b6a27/tim/opensearch.py#L452-L486)
   * When iterating over the responses from `streaming_bulk`, `bulk_index` and `bulk_update` check the value the `ok` boolean returned by the OpenSearch API.
      * When `ok=False` and it's due to allowed exceptions, it will increment error counts (see [`bulk_index`](https://github.com/MITLibraries/timdex-index-manager/blob/f240a3523e8ebad8e29a546aa62a3e34289b6a27/tim/opensearch.py#L404-L410) and [`bulk_update`](https://github.com/MITLibraries/timdex-index-manager/blob/f240a3523e8ebad8e29a546aa62a3e34289b6a27/tim/opensearch.py#L456-L465))
  * When iterating over the responses from `streaming_bulk`, `bulk_delete` only looks at the value of of `result`. 
     * All errors, including unknown ones, are simply recorded as an error, whether [`result="not_found"`](https://github.com/MITLibraries/timdex-index-manager/blob/f240a3523e8ebad8e29a546aa62a3e34289b6a27/tim/opensearch.py#L351-L357) or some other error occurred (which would include the 507 error).
     * If we want to retry failing deletes due to the 507 error and continue to capture any raised `TimeoutError` or `SingleOperationError`if the retry is unsuccessful, we would need to nest the logic inside a `try-except` block at the `bulk_delete` level.

   **TLDR:** The `bulk_*` method control flow is somewhat challenging to follow. I propose we get these changes merged and revisit the overall structure of the `bulk_*` methods instead of trying to retrofit the retry logic into `bulk_delete`. 🤔 

### How can a reviewer manually see the effects of these changes?

As shared in various discussions, I was unable to recreate the `HTTP 507 Insufficient Storage` error that was raised during TIMDEX source reindexing when running TIM in Dev1. @cabutlermit requested we move forward with implementing the `retry` solution on the agreement that we have unit tests confirming it functions as expected!

1. Review [these unit tests](https://github.com/MITLibraries/timdex-index-manager/blob/TIMX-639-retry-failures-from-ocu-scaling/tests/test_helpers.py#L12-L74) for the new `tim.helpers.retry` decorator
2. Review [these unit tests](https://github.com/MITLibraries/timdex-index-manager/pull/389/changes#diff-e2b10f9523be5f7c7fda7ac370df7c0db33c4a41ffe5dafc3a4e1a193a5573a2) for the updated control flow in `tim_os.bulk_index` and `tim_os.bulk_update` commands

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
YES - The length of time of a TIM execution that performs indexing or update operations may increase due to max timeout of 120 seconds allotted for every item/record operation that encounters an HTTP 507 error.

However, similar to the workflow prior to these changes, the the HTTP 507 error is encountered for a given record and either the timeout is reached:
* The **TIM execution will exit** with HTTP 507 error (ran out of attempts) OR
* The **TIM execution will exit** with unexpected error (ran out of attempts + last exception was not retryable error/not HTTP 507)

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-639

### Code review
* Code review best practices are documented [here](https://mitlibraries.github.io/guides/collaboration/code_review.html) and you are encouraged to have a constructive dialogue with your reviewers about their preferences and expectations.