### PR TITLE
Restructure tim.opensearch bulk methods and retry deletes

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,7 @@ from click.exceptions import BadParameter, UsageError
 from freezegun import freeze_time
 
 from tim.cli import main, validate_bulk_cli_options
-from tim.errors import BulkIndexingError, BulkOperationError
+from tim.errors import BulkActionError
 
 from .conftest import EXIT_CODES, my_vcr
 
@@ -242,8 +242,8 @@ def test_bulk_update_with_source_raise_bulk_indexing_error(
     runner,
 ):
     monkeypatch.delenv("TIMDEX_OPENSEARCH_ENDPOINT", raising=False)
-    mock_bulk_index.side_effect = BulkIndexingError(
-        record="alma:0", index="index", error="exception"
+    mock_bulk_index.side_effect = BulkActionError(
+        action="index", record="alma:0", index="index", error="exception"
     )
     mock_bulk_delete.return_value = {"deleted": 0, "errors": 0, "total": 0}
     mock_validate_bulk_cli_options.return_value = "alma"
@@ -322,7 +322,7 @@ def test_bulk_update_embeddings_exit_bulk_operation_error(
     mock_bulk_update, mock_validate_bulk_cli_options, caplog, monkeypatch, runner
 ):
     monkeypatch.delenv("TIMDEX_OPENSEARCH_ENDPOINT", raising=False)
-    mock_bulk_update.side_effect = BulkOperationError(
+    mock_bulk_update.side_effect = BulkActionError(
         action="update", record="alma:0", index="index", error="exception"
     )
     mock_validate_bulk_cli_options.return_value = "libguides"
@@ -419,7 +419,7 @@ def test_bulk_update_fulltexts_exit_bulk_operation_error(
     mock_bulk_update, mock_validate_bulk_cli_options, caplog, monkeypatch, runner
 ):
     monkeypatch.delenv("TIMDEX_OPENSEARCH_ENDPOINT", raising=False)
-    mock_bulk_update.side_effect = BulkOperationError(
+    mock_bulk_update.side_effect = BulkActionError(
         action="update", record="alma:0", index="index", error="exception"
     )
     mock_validate_bulk_cli_options.return_value = "libguides"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -6,7 +6,7 @@ from freezegun import freeze_time
 from opensearchpy.exceptions import TransportError
 
 from tim import helpers
-from tim.errors import SingleOperationError
+from tim.errors import RetryFailedWithUnexpectedError
 
 
 @freeze_time("2026-07-09 10:00:00", auto_tick_seconds=10)
@@ -69,7 +69,7 @@ def test_retry_decorator_raises_single_operation_error(mock_sleep):
     def hello_world():
         raise Exception("Unexpected error")  # noqa: TRY002
 
-    with pytest.raises(SingleOperationError):
+    with pytest.raises(RetryFailedWithUnexpectedError):
         hello_world()
 
 

--- a/tests/test_opensearch.py
+++ b/tests/test_opensearch.py
@@ -599,6 +599,32 @@ def test_bulk_delete_logs_error_if_record_not_found(
     )
 
 
+@pytest.mark.parametrize("mock_streaming_bulk", ["delete"], indirect=True)
+@mock.patch("tim.opensearch.execute_single_record_action")
+@mock.patch("tim.helpers.retry")
+def test_bulk_delete_retries_transport_error_507(
+    mock_retry,
+    mock_execute_single_record_action,
+    mock_streaming_bulk,
+    test_opensearch_client,
+    one_valid_index_libguides_records,
+):
+
+    mock_execute_single_record_action.return_value = {
+        "_index": "test-index",
+        "_id": "libguides:guides-175846",
+        "_version": 1,
+        "result": "deleted",
+    }
+    with mock.patch("tim.opensearch.streaming_bulk", side_effect=mock_streaming_bulk):
+        result = tim_os.bulk_delete(
+            test_opensearch_client, "test-index", one_valid_index_libguides_records
+        )
+
+    assert result["deleted"] == 1
+    assert mock_execute_single_record_action.call_count == 1
+
+
 @my_vcr.use_cassette("opensearch/bulk_update_updates_records.yaml")
 def test_bulk_update_updates_records(test_opensearch_client):
     updates = [

--- a/tim/cli.py
+++ b/tim/cli.py
@@ -9,7 +9,7 @@ from timdex_dataset_api import TIMDEXDataset
 from tim import errors, helpers
 from tim import opensearch as tim_os
 from tim.config import PRIMARY_ALIAS, VALID_SOURCES, configure_logger, configure_sentry
-from tim.errors import BulkIndexingError, BulkOperationError, SingleOperationError
+from tim.errors import BulkActionError, RetryFailedWithUnexpectedError
 
 logger = logging.getLogger(__name__)
 
@@ -313,7 +313,7 @@ def bulk_update(
     )
     try:
         index_results.update(tim_os.bulk_index(client, index, records_to_index))
-    except (BulkIndexingError, SingleOperationError, TimeoutError) as exception:
+    except (BulkActionError, RetryFailedWithUnexpectedError, TimeoutError) as exception:
         logger.error(f"Bulk indexing failed: {exception}")  # noqa: TRY400
 
     # bulk delete records
@@ -413,7 +413,7 @@ def bulk_update_embeddings(
     try:
         update_results = tim_os.bulk_update(client, index, embeddings_to_index)
         logger.info(f"Bulk update with embeddings complete: {json.dumps(update_results)}")
-    except (BulkOperationError, SingleOperationError, TimeoutError) as exception:
+    except (BulkActionError, RetryFailedWithUnexpectedError, TimeoutError) as exception:
         logger.error(f"Bulk update with embeddings failed: {exception}")  # noqa: TRY400
         ctx.exit(1)
 
@@ -499,7 +499,7 @@ def bulk_update_fulltexts(
     try:
         update_results = tim_os.bulk_update(client, index, fulltexts_to_index)
         logger.info(f"Bulk update with fulltexts complete: {json.dumps(update_results)}")
-    except (BulkOperationError, SingleOperationError, TimeoutError) as exception:
+    except (BulkActionError, RetryFailedWithUnexpectedError, TimeoutError) as exception:
         logger.error(f"Bulk update with fulltexts failed: {exception}")  # noqa: TRY400
         ctx.exit(1)
 
@@ -580,7 +580,7 @@ def reindex_source(
     )
     try:
         index_results.update(tim_os.bulk_index(client, index, records_to_index))
-    except (BulkIndexingError, SingleOperationError, TimeoutError) as exception:
+    except (BulkActionError, RetryFailedWithUnexpectedError, TimeoutError) as exception:
         logger.error(f"Bulk indexing failed: {exception}")  # noqa: TRY400
 
     # bulk index embeddings
@@ -602,7 +602,11 @@ def reindex_source(
         embeddings_to_index = helpers.format_embeddings(embeddings)
         try:
             update_results.update(tim_os.bulk_update(client, index, embeddings_to_index))
-        except (BulkOperationError, SingleOperationError, TimeoutError) as exception:
+        except (
+            BulkActionError,
+            RetryFailedWithUnexpectedError,
+            TimeoutError,
+        ) as exception:
             logger.error(  # noqa: TRY400
                 f"Bulk update with embeddings failed: {exception}"
             )

--- a/tim/errors.py
+++ b/tim/errors.py
@@ -19,7 +19,7 @@ class BulkIndexingError(Exception):
         super().__init__(self.message)
 
 
-class BulkOperationError(Exception):
+class BulkActionError(Exception):
     """Exception raised when an unexpected error is returned during a bulk operation."""
 
     def __init__(self, action: str, record: str, index: str, error: str) -> None:
@@ -35,8 +35,8 @@ class BulkOperationError(Exception):
         super().__init__(self.message)
 
 
-class SingleOperationError(Exception):
-    """Exception raised when an unexpected error occurs during a single operation."""
+class RetryFailedWithUnexpectedError(Exception):
+    """Exception raised when an unexpected error occurs during a retried operation."""
 
 
 class IndexExistsError(Exception):

--- a/tim/helpers.py
+++ b/tim/helpers.py
@@ -10,7 +10,7 @@ import click
 from opensearchpy.exceptions import TransportError
 
 from tim.config import VALID_BULK_OPERATIONS, VALID_SOURCES
-from tim.errors import SingleOperationError
+from tim.errors import RetryFailedWithUnexpectedError
 
 logger = logging.getLogger(__name__)
 TRANSPORT_ERROR_507 = 507
@@ -52,7 +52,7 @@ def retry(
                         logger.exception(
                             f"{func.__name__} raised unexpected exception, attempt {attempt}"  # noqa: E501
                         )
-                        raise SingleOperationError from exception
+                        raise RetryFailedWithUnexpectedError from exception
 
                 logger.debug(f"Sleeping {delay} seconds before retrying {func.__name__}")
                 time.sleep(delay * attempt)

--- a/tim/opensearch.py
+++ b/tim/opensearch.py
@@ -18,10 +18,10 @@ from tim.config import (
 )
 from tim.errors import (
     AliasNotFoundError,
-    BulkIndexingError,
-    BulkOperationError,
+    BulkActionError,
     IndexExistsError,
     IndexNotFoundError,
+    RetryFailedWithUnexpectedError,
 )
 
 logger = logging.getLogger(__name__)
@@ -333,12 +333,21 @@ def bulk_delete(
 ) -> dict[str, int]:
     """Delete records from an existing index using the streaming bulk helper.
 
-    If an error occurs during record deletion, it will be logged and bulk deletion will
-    continue until all records have been processed.
+    The `streaming_bulk()` method returns a tuple with a boolean indicating whether
+    the action succeeded and the API response as a dict. The "result" value in the
+    API response is used to identify successful actions.
+        - If result="not_found", the error message is logged
+          and the method continues.
+        - If an error is caused by a `TransportError` with status 507
+          ("Insufficient Storage"), the method will retry the "index" action for
+          the record. If the retry results in a `RetryFailedWithUnexpectedError`
+          or `TimeoutError`, the exception is logged and the method continues.
+        - If an error is unknown, the error message is logged
+          and the method continues.
 
     Returns total sums of: records deleted, errors, and total records processed.
     """
-    result = {"deleted": 0, "errors": 0, "total": 0}
+    result_summary = {"deleted": 0, "errors": 0, "total": 0}
     actions = helpers.generate_bulk_actions(index, records, "delete")
     responses = streaming_bulk(
         client,
@@ -349,39 +358,69 @@ def bulk_delete(
         max_chunk_bytes=REQUEST_CONFIG["OPENSEARCH_BULK_MAX_CHUNK_BYTES"],
         raise_on_error=False,
     )
-    for response in responses:
-        logger.debug(response)
-        if response[1]["delete"].get("result") == "not_found":
+    for _, item in responses:
+        action, response = next(iter(item.items()))
+
+        # parse item details from response
+        record_id = response.get("_id")
+        status = response.get("status")
+        result = response.get("result")
+
+        if result == "deleted":
+            result_summary["deleted"] += 1
+        elif result == "not_found":
             logger.error(
                 "Record to delete '%s' was not found in index '%s'.",
-                response[1]["delete"]["_id"],
+                record_id,
                 index,
             )
-            result["errors"] += 1
-        elif response[1]["delete"].get("result") == "deleted":
-            result["deleted"] += 1
+            result_summary["errors"] += 1
+        elif status == TRANSPORT_ERROR_507:
+            try:
+                execute_single_record_action(
+                    client, index, record_id=record_id, action=action
+                )
+                result_summary["deleted"] += 1
+            except (RetryFailedWithUnexpectedError, TimeoutError):
+                logger.exception(f"Retries of '{action}' for {record_id} failed")
+                result_summary["errors"] += 1
         else:
             logger.error(
                 "Something unexpected happened during deletion. Bulk delete response: %s",
                 json.dumps(response),
             )
-            result["errors"] += 1
-        result["total"] += 1
-        if result["total"] % int(os.getenv("STATUS_UPDATE_INTERVAL", "1000")) == 0:
-            logger.info("Status update: %s records deleted so far!", result["total"])
-    return result
+            result_summary["errors"] += 1
+        result_summary["total"] += 1
+
+        if (
+            result_summary["total"] % int(os.getenv("STATUS_UPDATE_INTERVAL", "1000"))
+            == 0
+        ):
+            logger.info(
+                "Status update: %s records deleted so far!", result_summary["total"]
+            )
+
+    return result_summary
 
 
 def bulk_index(client: OpenSearch, index: str, records: Iterator[dict]) -> dict[str, int]:
     """Indexes records into an existing index using the streaming bulk helper.
 
     This action function uses the OpenSearch "index" action, which is a
-    combination of create and update: if a record with the same _id exists in the
+    combination of create and update: if a record with the same `_id` exists in the
     index, it will be updated. If it does not exist, the record will be indexed as a
     new document.
 
-    If an error occurs during record indexing, it will be logged and bulk indexing will
-    continue until all records have been processed.
+    The `streaming_bulk()` method returns a tuple with a boolean indicating whether
+    the action succeeded and the API response as a dict. The "result" value in the
+    API response is used to identify successful actions.
+        - If an error is caused by "mapper parsing", the error message
+          is logged, the record is skipped, and the method continues indexing.
+        - If an error is caused by a `TransportError` with status 507
+          ("Insufficient Storage"), the method will retry the "index" action for
+          the record. If the retry results in a `RetryFailedWithUnexpectedError`
+          or `TimeoutError`, the exception propagates to the caller.
+        - If an error is unknown, a `BulkActionError` is raised.
 
     NOTE: The update performed by the "index" action results in a full replacement of the
     document in OpenSearch. If a partial record is provided, this will result in a new
@@ -390,7 +429,7 @@ def bulk_index(client: OpenSearch, index: str, records: Iterator[dict]) -> dict[
     Returns total sums of: records created, records updated, errors, and total records
     processed.
     """
-    result = {"created": 0, "updated": 0, "errors": 0, "total": 0}
+    result_summary = {"created": 0, "updated": 0, "errors": 0, "total": 0}
     actions_cache: defaultdict = defaultdict(deque)
     actions = helpers.generate_bulk_actions(index, records, "index", actions_cache)
     responses = streaming_bulk(
@@ -401,48 +440,56 @@ def bulk_index(client: OpenSearch, index: str, records: Iterator[dict]) -> dict[
         max_chunk_bytes=REQUEST_CONFIG["OPENSEARCH_BULK_MAX_CHUNK_BYTES"],
         raise_on_error=False,
     )
-    for response in responses:
-        record_id = response[1]["index"]["_id"]
-        if response[0] is False:
-            status = response[1]["index"]["status"]
-            error = response[1]["index"]["error"]
-            if error["type"] == "mapper_parsing_exception":
-                logger.error(
-                    "Error indexing record '%s'. Details: %s",
-                    record_id,
-                    json.dumps(error),
-                )
-                result["errors"] += 1
-            elif status == TRANSPORT_ERROR_507:
-                retry_response = execute_single_record_action(
-                    client,
-                    index,
-                    record_id=record_id,
-                    body=actions_cache[record_id][0]["_source"],
-                    operation="index",
-                )
-                result[retry_response["result"]] += 1
-            else:
-                raise BulkIndexingError(record_id, index, json.dumps(error))
-        elif response[1]["index"].get("result") == "created":
-            result["created"] += 1
-        elif response[1]["index"].get("result") == "updated":
-            result["updated"] += 1
-        else:
+    for _, item in responses:
+        action, response = next(iter(item.items()))
+
+        # parse item details from response
+        record_id = response.get("_id")
+        status = response.get("status")
+        result = response.get("result")
+        error = response.get("error")
+
+        if result == "created":
+            result_summary["created"] += 1
+        elif result == "updated":
+            result_summary["updated"] += 1
+        elif error["type"] == "mapper_parsing_exception":
             logger.error(
-                "Something unexpected happened during ingest. Bulk index response: %s",
-                json.dumps(response),
+                "Error indexing record '%s'. Details: %s",
+                record_id,
+                json.dumps(error),
             )
-            result["errors"] += 1
-        result["total"] += 1
+            result_summary["errors"] += 1
+        elif status == TRANSPORT_ERROR_507:
+            retry_response = execute_single_record_action(
+                client,
+                index,
+                record_id=record_id,
+                body=actions_cache[record_id][0]["_source"],
+                action=action,
+            )
+            result_summary[retry_response["result"]] += 1
+        else:
+            raise BulkActionError(
+                action=action,
+                record=record_id,
+                index=index,
+                error=json.dumps(error),
+            )
+        result_summary["total"] += 1
 
         # remove record action from cache after processing
         helpers.pop_cache_entry(actions_cache, record_id)
 
-        if result["total"] % int(os.getenv("STATUS_UPDATE_INTERVAL", "1000")) == 0:
-            logger.info("Status update: %s records indexed so far!", result["total"])
+        if (
+            result_summary["total"] % int(os.getenv("STATUS_UPDATE_INTERVAL", "1000"))
+            == 0
+        ):
+            logger.info(
+                "Status update: %s records indexed so far!", result_summary["total"]
+            )
 
-    return result
+    return result_summary
 
 
 def bulk_update(
@@ -455,10 +502,22 @@ def bulk_update(
     a full or partial record and will only update the corresponding fields in the
     document.
 
+    The `streaming_bulk()` method returns a tuple with a boolean indicating whether
+    the action succeeded and the API response as a dict. The "result" value in the
+    API response is used to identify successful actions.
+        - If an error is caused by "mapper parsing" or "document missing",
+          the error message is logged, the record is skipped, and the method continues
+          indexing.
+        - If an error is caused by a `TransportError` with status 507
+          ("Insufficient Storage"), the method will retry the "index" action for
+          the record. If the retry results in a `RetryFailedWithUnexpectedError`
+          or `TimeoutError`, the exception propagates to the caller.
+        - If an error is unknown, a `BulkActionError` is raised.
+
     Returns total sums of: records updated, errors, and total records
     processed.
     """
-    result = {"updated": 0, "skipped": 0, "errors": 0, "total": 0}
+    result_summary = {"updated": 0, "skipped": 0, "errors": 0, "total": 0}
     actions_cache: defaultdict = defaultdict(deque)
     actions = helpers.generate_bulk_actions(index, records, "update", actions_cache)
     responses = streaming_bulk(
@@ -469,65 +528,71 @@ def bulk_update(
         max_chunk_bytes=REQUEST_CONFIG["OPENSEARCH_BULK_MAX_CHUNK_BYTES"],
         raise_on_error=False,
     )
-    for response in responses:
-        record_id = response[1]["update"]["_id"]
-        if response[0] is False:
-            status = response[1]["update"]["status"]
-            error = response[1]["update"]["error"]
-            if error["type"] in [
-                "mapper_parsing_exception",
-                "document_missing_exception",
-            ]:
-                logger.error(
-                    "Error updating record '%s'. Details: %s",
-                    record_id,
-                    json.dumps(error),
-                )
-                result["errors"] += 1
-            elif status == TRANSPORT_ERROR_507:
-                retry_response = execute_single_record_action(
-                    client,
-                    index,
-                    record_id=record_id,
-                    body=actions_cache[record_id][0]["doc"],
-                    operation="update",
-                )
-                if retry_response["result"] == "updated":
-                    result["updated"] += 1
-                elif retry_response["result"] == "noop":
-                    result["skipped"] += 1
-            else:
-                message = "update"
-                raise BulkOperationError(
-                    message,
-                    record_id,
-                    index,
-                    json.dumps(error),
-                )
-        elif response[1]["update"].get("result") == "updated":
-            result["updated"] += 1
-        elif response[1]["update"].get("result") == "noop":
-            result["skipped"] += 1
-        else:
+    for _, item in responses:
+        action, response = next(iter(item.items()))
+
+        # parse item details from response
+        record_id = response.get("_id")
+        status = response.get("status")
+        result = response.get("result")
+        error = response.get("error")
+
+        if result == "updated":
+            result_summary["updated"] += 1
+        elif result == "noop":
+            result_summary["skipped"] += 1
+        elif error["type"] in [
+            "mapper_parsing_exception",
+            "document_missing_exception",
+        ]:
             logger.error(
-                "Something unexpected happened during update. Bulk update response: %s",
-                json.dumps(response),
+                "Error updating record '%s'. Details: %s",
+                record_id,
+                json.dumps(error),
             )
-            result["errors"] += 1
-        result["total"] += 1
+            result_summary["errors"] += 1
+        elif status == TRANSPORT_ERROR_507:
+            retry_response = execute_single_record_action(
+                client,
+                index,
+                record_id=record_id,
+                body=actions_cache[record_id][0]["doc"],
+                action=action,
+            )
+            if retry_response["result"] == "updated":
+                result_summary["updated"] += 1
+            elif retry_response["result"] == "noop":
+                result_summary["skipped"] += 1
+        else:
+            raise BulkActionError(
+                action=action,
+                record=record_id,
+                index=index,
+                error=json.dumps(error),
+            )
+        result_summary["total"] += 1
 
         # remove record action from cache after processing
         helpers.pop_cache_entry(actions_cache, record_id)
 
-        if result["total"] % int(os.getenv("STATUS_UPDATE_INTERVAL", "1000")) == 0:
-            logger.info("Status update: %s records updated so far!", result["total"])
+        if (
+            result_summary["total"] % int(os.getenv("STATUS_UPDATE_INTERVAL", "1000"))
+            == 0
+        ):
+            logger.info(
+                "Status update: %s records updated so far!", result_summary["total"]
+            )
 
-    return result
+    return result_summary
 
 
 @helpers.retry()
 def execute_single_record_action(
-    client: OpenSearch, index: str, record_id: str, body: dict, operation: str
+    client: OpenSearch,
+    index: str,
+    record_id: str,
+    action: str,
+    body: dict | None = None,
 ) -> dict[str, Any]:
     """Execute an OpenSearch action for a single record.
 
@@ -535,13 +600,13 @@ def execute_single_record_action(
     is dispatched to the corresponding OpenSearch client method based on
     `operation`.
     """
-    logger.info(f"Retrying '{operation}' operation for {record_id}")
-    method = getattr(client, operation)
-    if operation == "index":
+    logger.info(f"Retrying '{action}' operation for {record_id}")
+    method = getattr(client, action)
+    if action == "index":
         method_args = {"index": index, "id": record_id, "body": body}
-    elif operation == "update":
+    elif action == "update":
         method_args = {"index": index, "id": record_id, "body": {"doc": body}}
-    elif operation == "delete":
+    elif action == "delete":
         method_args = {
             "index": index,
             "id": record_id,


### PR DESCRIPTION
### Purpose and background context
The three bulk methods for indexing, updating, and deleting records from an OpenSearch index defined in `tim.opensearch` share a lot of the same code, but it was somewhat difficult to understand what was happening in its previous structure. The changes in this PR were intended to make the code easier to follow and set a clear path for integrating the retry solution for the `bulk_delete` method.

The main changes introduced in this PR is [unpacking the tuple returned by `streaming_bulk`](https://github.com/MITLibraries/timdex-index-manager/blob/afb61a5bf4b5f0ce3cee1c9878c93d7e5b81821d/tim/opensearch.py#L352), followed by [unpacking a key-value pair from a dictionary item](https://github.com/MITLibraries/timdex-index-manager/blob/afb61a5bf4b5f0ce3cee1c9878c93d7e5b81821d/tim/opensearch.py#L353). Applying these two changes simplified the way we access attributes in the response object (i.e., no more `response[<index>][<operation]...`). The commit message for afb61a5bf4b5f0ce3cee1c9878c93d7e5b81821d describes the general control flow structure in more detail.

**Note:** When I originally started on this work, I was initially thinking I'd be introducing significant changes to the PR to remove the duplicated steps/code in `bulk_*` commands. However, the subtle differences for each method, such as:
* what key it updates in `result_summary`
   * `bulk_index` tracked `["created", "updated"]`
   * `bulk_update` tracked `["updated", "skipped"]`
   * `bulk_delete` tracked `["deleted"]`
* whether to raise an error
   * `bulk_index` and `bulk_update` raise `BulkOperationError` when original response is non-loggable or non-retryable error and raises `SingleOperationError` or `TimeoutError` for failed retries
   * `bulk_delete` handles all errors, incrementing `"errors"` count
* what are considered loggable errors
   * [`bulk_index` allows `mapper_parsing_exception`](https://github.com/MITLibraries/timdex-index-manager/blob/TIMX-639-clean-up-bulk-methods-and-retry-deletes/tim/opensearch.py#L440-L446)
   * [`bulk_update` allows `mapper_parsing_exception` and `document_missing_exception`](https://github.com/MITLibraries/timdex-index-manager/blob/TIMX-639-clean-up-bulk-methods-and-retry-deletes/tim/opensearch.py#L517-L526)

make it challenging to abstract the method into smaller methods. Ultimately, I decided that implementing a private, sub-method was not worth it at this time and that a future larger-scale, refactoring of TIM would benefit from the individual, written out `bulk_*` method definitions!

### How can a reviewer manually see the effects of these changes?
See [added unit test](https://github.com/MITLibraries/timdex-index-manager/blob/TIMX-639-clean-up-bulk-methods-and-retry-deletes/tests/test_opensearch.py#L602-L625).

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-639


### Code review
* Code review best practices are documented [here](https://mitlibraries.github.io/guides/collaboration/code_review.html) and you are encouraged to have a constructive dialogue with your reviewers about their preferences and expectations.