### PR TITLE
Retries resulting in allowed errors are handled

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 import pytest
 from click.exceptions import BadParameter
 from freezegun import freeze_time
-from opensearchpy.exceptions import TransportError
+from opensearchpy.exceptions import NotFoundError, RequestError, TransportError
 
 from tim import helpers
 from tim.errors import RetryFailedWithUnexpectedError
@@ -62,7 +62,7 @@ def test_retry_decorator_without_sleep(mock_sleep):
 
 
 @patch("tim.helpers.time.sleep")
-def test_retry_decorator_raises_single_operation_error(mock_sleep):
+def test_retry_decorator_raises_retry_failed_with_unexpected_error(mock_sleep):
     """Retry resulting in unexpected error raises error."""
 
     @helpers.retry()
@@ -70,6 +70,34 @@ def test_retry_decorator_raises_single_operation_error(mock_sleep):
         raise Exception("Unexpected error")  # noqa: TRY002
 
     with pytest.raises(RetryFailedWithUnexpectedError):
+        hello_world()
+
+
+@patch("tim.helpers.time.sleep")
+def test_retry_decorator_raises_not_found_error(mock_sleep):
+    """Retry raises NotFoundError caused by missing documents."""
+
+    @helpers.retry()
+    def hello_world():
+        raise NotFoundError
+
+    with pytest.raises(NotFoundError):
+        hello_world()
+
+
+@patch("tim.helpers._is_mapper_parsing_exception")
+@patch("tim.helpers.time.sleep")
+def test_retry_decorator_raises_mapper_parsing_request_error(
+    mock_sleep, mock_is_mapper_parsing_exception
+):
+    """Retry raises RequestError caused by mapper parsing exception."""
+    mock_is_mapper_parsing_exception.return_value = True
+
+    @helpers.retry()
+    def hello_world():
+        raise RequestError
+
+    with pytest.raises(RequestError):
         hello_world()
 
 

--- a/tests/test_opensearch.py
+++ b/tests/test_opensearch.py
@@ -657,7 +657,7 @@ def test_bulk_update_records_error_record_not_found(
     results = tim_os.bulk_update(test_opensearch_client, "test-index", iter(updates))
     assert results["errors"] == 1
     assert (
-        """Error updating record 'i-am-not-found'. """
+        """Error updating record 'i-am-not-found' with status 404. """
         """Details: {"type": "document_missing_exception", """
         """"reason": "[i-am-not-found]: document missing","""
     ) in caplog.text

--- a/tim/helpers.py
+++ b/tim/helpers.py
@@ -7,7 +7,7 @@ from collections.abc import Callable, Generator, Iterator
 from datetime import UTC, datetime
 
 import click
-from opensearchpy.exceptions import TransportError
+from opensearchpy.exceptions import NotFoundError, RequestError, TransportError
 
 from tim.config import VALID_BULK_OPERATIONS, VALID_SOURCES
 from tim.errors import RetryFailedWithUnexpectedError
@@ -21,6 +21,18 @@ def retry(
     max_attempts: int = 8,
 ) -> Callable:
     """Retry the decorated function until success or max attempts reached.
+
+    This retry is opinionated towards uses of opensearchpy's non-bulk API methods,
+    which raise exceptions when OpenSearch returns an error response. The retry
+    handles the following errors:
+        - NotFoundError: Raised when 'update' or 'delete' action cannot find document
+          - Effect: Re-raise exception
+        - RequestError (mapper parsing exception): Raised when 'index' or 'update'
+          cannot map document to schema/mapping
+          - Effect: Re-raise exception
+        - TransportError (507, "Insufficient Storage"): May be raised when AOSS requires
+          OCU scaling.
+          - Effect: Delay with progressive backoff
 
     Args:
         delay: Time to wait, in seconds, between retry attempts. This value is
@@ -39,6 +51,15 @@ def retry(
 
                 try:
                     return func(*args, **kwargs)
+                except NotFoundError:
+                    raise
+                except RequestError as exception:
+                    if _is_mapper_parsing_exception(exception):
+                        raise
+                    logger.exception(
+                        f"{func.__name__} raised unexpected exception, attempt {attempt}"
+                    )
+                    raise RetryFailedWithUnexpectedError from exception
                 except Exception as exception:
                     if (
                         isinstance(exception, TransportError)
@@ -62,6 +83,31 @@ def retry(
         return wrapper
 
     return retry_decorator
+
+
+def _is_mapper_parsing_exception(exception: Exception) -> bool:
+    if not isinstance(exception, RequestError):
+        return False
+
+    info = getattr(exception, "info", None)
+    if not isinstance(info, dict):
+        return False
+
+    error = info.get("error")
+    if not isinstance(error, dict):
+        return False
+
+    if error.get("type") == "mapper_parsing_exception":
+        return True
+
+    root_cause = error.get("root_cause", [])
+    if isinstance(root_cause, list):
+        return any(
+            isinstance(cause, dict) and cause.get("type") == "mapper_parsing_exception"
+            for cause in root_cause
+        )
+
+    return False
 
 
 def confirm_action(input_prompt: str) -> bool:

--- a/tim/opensearch.py
+++ b/tim/opensearch.py
@@ -381,7 +381,7 @@ def bulk_delete(
                     client, index, record_id=record_id, action=action
                 )
                 result_summary["deleted"] += 1
-            except (RetryFailedWithUnexpectedError, TimeoutError):
+            except (NotFoundError, RetryFailedWithUnexpectedError, TimeoutError):
                 logger.exception(f"Retries of '{action}' for {record_id} failed")
                 result_summary["errors"] += 1
         else:
@@ -455,20 +455,29 @@ def bulk_index(client: OpenSearch, index: str, records: Iterator[dict]) -> dict[
             result_summary["updated"] += 1
         elif error["type"] == "mapper_parsing_exception":
             logger.error(
-                "Error indexing record '%s'. Details: %s",
+                "Error indexing record '%s' with status %s. Details: %s",
                 record_id,
+                status,
                 json.dumps(error),
             )
             result_summary["errors"] += 1
         elif status == TRANSPORT_ERROR_507:
-            retry_response = execute_single_record_action(
-                client,
-                index,
-                record_id=record_id,
-                body=actions_cache[record_id][0]["_source"],
-                action=action,
-            )
-            result_summary[retry_response["result"]] += 1
+            try:
+                retry_response = execute_single_record_action(
+                    client,
+                    index,
+                    record_id=record_id,
+                    body=actions_cache[record_id][0]["_source"],
+                    action=action,
+                )
+                result_summary[retry_response["result"]] += 1
+            except RequestError as exception:
+                logger.exception(
+                    "Error indexing record '%s' with status %s.",
+                    record_id,
+                    exception.status_code,
+                )
+                result_summary["errors"] += 1
         else:
             raise BulkActionError(
                 action=action,
@@ -546,23 +555,32 @@ def bulk_update(
             "document_missing_exception",
         ]:
             logger.error(
-                "Error updating record '%s'. Details: %s",
+                "Error updating record '%s' with status %s. Details: %s",
                 record_id,
+                status,
                 json.dumps(error),
             )
             result_summary["errors"] += 1
         elif status == TRANSPORT_ERROR_507:
-            retry_response = execute_single_record_action(
-                client,
-                index,
-                record_id=record_id,
-                body=actions_cache[record_id][0]["doc"],
-                action=action,
-            )
-            if retry_response["result"] == "updated":
-                result_summary["updated"] += 1
-            elif retry_response["result"] == "noop":
-                result_summary["skipped"] += 1
+            try:
+                retry_response = execute_single_record_action(
+                    client,
+                    index,
+                    record_id=record_id,
+                    body=actions_cache[record_id][0]["doc"],
+                    action=action,
+                )
+                if retry_response["result"] == "updated":
+                    result_summary["updated"] += 1
+                elif retry_response["result"] == "noop":
+                    result_summary["skipped"] += 1
+            except (NotFoundError, RequestError) as exception:
+                logger.exception(
+                    "Error updating record '%s' with status %s.",
+                    record_id,
+                    exception.status_code,
+                )
+                result_summary["errors"] += 1
         else:
             raise BulkActionError(
                 action=action,


### PR DESCRIPTION
### Purpose and background context
If a retry results in an allowed error, these errors should be handled as well. It's important to note that during a retry of a failed action, TIM uses the single-document APIs (i.e., the `index`, `update`, and `delete` methods), which will raise exceptions whereas streaming_bulk(raise_on_error=False) did not. The retry decorator has been updated to re-raise `NotFoundError` and `RequestError` caused by mapper parsing exception so they can be handled by the corresponding `tim.opensearch.bulk_*` methods.

### How can a reviewer manually see the effects of these changes?
Review [added unit tests](https://github.com/MITLibraries/timdex-index-manager/pull/391/changes#diff-08a6944653efc734f4c8cb856fc854b9f21d655ca69796af2b170c53bff7919eR76-R101).

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
* https://mitlibraries.atlassian.net/browse/TIMX-639

### Code review
* Code review best practices are documented [here](https://mitlibraries.github.io/guides/collaboration/code_review.html) and you are encouraged to have a constructive dialogue with your reviewers about their preferences and expectations.