### PR TITLE
Bulk update handles "document_missing_in_index_exception"

### DIFF
--- a/tim/opensearch.py
+++ b/tim/opensearch.py
@@ -553,6 +553,7 @@ def bulk_update(
         elif error["type"] in [
             "mapper_parsing_exception",
             "document_missing_exception",
+            "document_missing_in_index_exception",
         ]:
             logger.error(
                 "Error updating record '%s' with status %s. Details: %s",


### PR DESCRIPTION
### Purpose and background context

This required update was identified in the process of investigating missing TIMDEX embeddings for `gismit` and `aspace`. This fix addresses the missing embeddings for `gismit`. **Please read the details in [TIMX-642](https://mitlibraries.atlassian.net/browse/TIMX-642) for a summary of the issue.**

One might wonder--as I did 🤓 --the difference between the `document_missing_exception` vs `document_missing_in_index` exception. The screenshot in TIMX-642 showing the `document_missing_in_index` exception was reindexing to AOSS (Serverless) and the screenshot **below** is reindexing to Cluster (Traditional):
<img width="1032" height="546" alt="image" src="https://github.com/user-attachments/assets/8c2f14ff-383e-4f6b-be15-858f4c52fe0a" />

This suggests that the `document_missing_in_index` is specific to AOSS and it is an artifact of differing OpenSearch versions used by AOSS (Serverless) vs. Cluster (Traditional). While we are supporting two OpenSearch instances, we will need to handle both error types.

### How can a reviewer manually see the effects of these changes?
Screenshots in TIMX-642 and above for the `gismit` explain the issue.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
YES-ish: The TIMDEX dataset in Prod was synced to Dev on 2026-07-14 (yesterday). The TIMDEX dataset in Prod will still be missing embeddings for `gismit` and `aspace` until we regenerate embeddings as was done in Dev.

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-642

### Code review
* Code review best practices are documented [here](https://mitlibraries.github.io/guides/collaboration/code_review.html) and you are encouraged to have a constructive dialogue with your reviewers about their preferences and expectations.

[TIMX-642]: https://mitlibraries.atlassian.net/browse/TIMX-642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ